### PR TITLE
Add hash-bake subcommand (v0.7.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,7 +1667,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perf-sentinel"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "perf-sentinel-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sentinel-core", "crates/sentinel-cli"]
 resolver = "3"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 license = "AGPL-3.0-only"
 rust-version = "1.95.0"

--- a/charts/perf-sentinel/CHANGELOG.md
+++ b/charts/perf-sentinel/CHANGELOG.md
@@ -6,6 +6,24 @@ Chart versions are independent from the perf-sentinel application
 versions, the chart's `appVersion` field tracks which daemon version is
 the default target.
 
+## [0.2.37]
+
+### Added
+
+- `appVersion` bumped to `0.7.2`, the default daemon image tag now
+  points at `ghcr.io/robintra/perf-sentinel:0.7.2`. The
+  `artifacthub.io/images` annotation is updated in lockstep. The
+  0.7.2 binary adds the `hash-bake` subcommand: it reads a periodic
+  disclosure report, computes the canonical `content_hash` applying
+  the `POST_SIGN_FIELDS` blanching, writes the hash into
+  `integrity.content_hash`, and saves the result via an atomic
+  temp+rename. Intended for test fixture generation and debugging
+  workflows where a report needs a hash matching what perf-sentinel
+  itself would write. Signed reports (those carrying
+  `integrity.signature`) are rejected by default with exit 1, opt-in
+  via `--allow-signed`. Exit codes: 0 success, 1 refused, 3 input
+  error.
+
 ## [0.2.36]
 
 ### Changed

--- a/charts/perf-sentinel/Chart.yaml
+++ b/charts/perf-sentinel/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   pool saturation, serialized parallelizable calls, fanout. Scores I/O
   intensity per endpoint (GreenOps).
 type: application
-version: 0.2.36
-appVersion: "0.7.1"
+version: 0.2.37
+appVersion: "0.7.2"
 kubeVersion: ">=1.24.0-0"
 home: https://github.com/robintra/perf-sentinel
 icon: https://raw.githubusercontent.com/robintra/perf-sentinel/main/logo/logo-horizontal.svg
@@ -37,11 +37,11 @@ annotations:
     - name: Helm deployment guide
       url: https://github.com/robintra/perf-sentinel/blob/main/docs/HELM-DEPLOYMENT.md
   artifacthub.io/changes: |
-    - kind: changed
-      description: "appVersion 0.7.1: SLSA build provenance pipeline migrated from `slsa-framework/slsa-github-generator` (in de-facto maintenance since 2025-02) to GitHub-native `actions/attest-build-provenance`. Attestations now live in the GitHub attestations API, queried via `gh attestation verify`, instead of the legacy `multiple.intoto.jsonl` release asset. SLSA level claim bumped from L2 to L3 (the new action produces a level-3 attestation by construction). Daemon advisory `[reporting] disclose_output_path` warning now emitted exactly once at startup. Breaking change for consumers scripting `slsa-verifier verify-artifact` on 0.7.1+ binaries: migrate to `gh attestation verify <binary> --owner robintra --repo perf-sentinel` (requires gh CLI 2.49+)."
+    - kind: added
+      description: "appVersion 0.7.2: new `perf-sentinel hash-bake` subcommand. Reads a periodic disclosure report, computes the canonical `content_hash` (applying the `POST_SIGN_FIELDS` blanching), writes it into `integrity.content_hash`, and saves the result via an atomic temp+rename. Intended for test fixture generation and debugging workflows that need a report whose hash matches what perf-sentinel itself would produce. Refuses signed reports by default to guard against unintended rewrites, opt in with `--allow-signed`. Exit codes 0 (success), 1 (refused signed without flag), 3 (input error)."
   artifacthub.io/images: |
     - name: perf-sentinel
-      image: ghcr.io/robintra/perf-sentinel:0.7.1
+      image: ghcr.io/robintra/perf-sentinel:0.7.2
       platforms:
         - linux/amd64
         - linux/arm64

--- a/crates/sentinel-cli/Cargo.toml
+++ b/crates/sentinel-cli/Cargo.toml
@@ -32,7 +32,7 @@ tempo = ["perf-sentinel-core/tempo"]
 jaeger-query = ["perf-sentinel-core/jaeger-query"]
 
 [dependencies]
-perf-sentinel-core = { version = "0.7.1", path = "../sentinel-core" }
+perf-sentinel-core = { version = "0.7.2", path = "../sentinel-core" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap_complete = "4.6.5"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/crates/sentinel-cli/src/hash_bake.rs
+++ b/crates/sentinel-cli/src/hash_bake.rs
@@ -6,16 +6,22 @@
 //! atomically. Intended for test fixture generation and debugging when a
 //! report's hash has drifted from canonical.
 //!
+//! The input file is capped at 64 MiB. The temp file is created
+//! with `create_new` (and `O_NOFOLLOW` on unix) so a stale
+//! `<output>.tmp` or a hostile symlink at that path triggers an exit
+//! 3 instead of silently clobbering the target.
+//!
 //! Exit codes:
 //!
 //! - `0` success
 //! - `1` refused (`integrity.signature` already populated and
 //!   `--allow-signed` not passed)
-//! - `3` `INPUT_ERROR` (read failure, JSON parse error, write failure)
+//! - `3` `INPUT_ERROR` (file unreadable, JSON parse error, file over
+//!   the size cap, temp file path collision, write failure)
 
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::{BufWriter, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use sentinel_core::report::periodic::{compute_content_hash, schema::PeriodicReport};
 use sentinel_core::text_safety::sanitize_for_terminal;
@@ -24,8 +30,36 @@ pub const EXIT_OK: i32 = 0;
 pub const EXIT_REFUSED: i32 = 1;
 pub const EXIT_INPUT_ERROR: i32 = 3;
 
+// Hard cap on the input report size. Legitimate periodic disclosures
+// are well under 10 MB, 64 MiB leaves room for outliers (deep G1
+// archives, large per-service breakdowns) while bounding the
+// allocation a single CLI invocation will perform.
+const MAX_REPORT_BYTES: u64 = 64 * 1024 * 1024;
+
 /// Entry point invoked from `main.rs` dispatch.
 pub fn cmd_hash_bake(report_path: &Path, output_path: &Path, allow_signed: bool) -> i32 {
+    // Refuse oversized inputs before allocating to bound the worst
+    // case (poisoned mirror feeding a multi-GB JSON to a CI runner).
+    match fs::metadata(report_path) {
+        Ok(meta) if meta.len() > MAX_REPORT_BYTES => {
+            eprintln!(
+                "Error: report at {} is {} bytes, exceeds the {}-byte cap.",
+                sanitize_for_terminal(&report_path.display().to_string()),
+                meta.len(),
+                MAX_REPORT_BYTES
+            );
+            return EXIT_INPUT_ERROR;
+        }
+        Err(err) => {
+            eprintln!(
+                "Error: failed to stat report at {}: {err}",
+                sanitize_for_terminal(&report_path.display().to_string())
+            );
+            return EXIT_INPUT_ERROR;
+        }
+        Ok(_) => {}
+    }
+
     let bytes = match fs::read(report_path) {
         Ok(b) => b,
         Err(err) => {
@@ -50,13 +84,11 @@ pub fn cmd_hash_bake(report_path: &Path, output_path: &Path, allow_signed: bool)
 
     if report.integrity.signature.is_some() && !allow_signed {
         eprintln!(
-            "Error: report at {} already has integrity.signature populated.",
+            "Error: report at {} already has integrity.signature populated.\n\
+             The canonical content_hash excludes integrity.signature, so re-baking does not invalidate an existing signature.\n\
+             This refusal guards against accidental overwrites of signed reports. Pass --allow-signed to proceed.",
             sanitize_for_terminal(&report_path.display().to_string())
         );
-        eprintln!(
-            "Re-baking would not invalidate the signature (content_hash blanches signature in canonical form), but you should confirm the intent."
-        );
-        eprintln!("Pass --allow-signed to proceed.");
         return EXIT_REFUSED;
     }
 
@@ -84,8 +116,26 @@ pub fn cmd_hash_bake(report_path: &Path, output_path: &Path, allow_signed: bool)
 // Write `report` to `output` atomically via a sibling `.tmp` file and
 // `rename`. Cleans up the temp on rename failure (best effort).
 fn write_atomic_pretty(report: &PeriodicReport, output: &Path) -> Result<(), i32> {
-    let tmp = output.with_extension("tmp");
-    let file = match fs::File::create(&tmp) {
+    // Append `.tmp` instead of replacing the extension so a path like
+    // `report.tmp` (whose extension is already `tmp`) does not collide
+    // with itself, which would defeat the atomic guarantee.
+    let tmp = {
+        let mut buf = output.as_os_str().to_owned();
+        buf.push(".tmp");
+        PathBuf::from(buf)
+    };
+    // `create_new` fails if the temp already exists, and `O_NOFOLLOW`
+    // refuses to follow a symlink at that path. Together they defeat
+    // the symlink-clobber attack a co-located process could attempt
+    // on a shared CI workspace.
+    let mut opts = OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = match opts.open(&tmp) {
         Ok(f) => f,
         Err(err) => {
             eprintln!(
@@ -169,6 +219,34 @@ mod tests {
         assert_eq!(baked.integrity.content_hash, recomputed);
         let zero_placeholder = format!("sha256:{}", "0".repeat(64));
         assert_ne!(baked.integrity.content_hash, zero_placeholder);
+        // The temp file must not survive a successful bake.
+        let leaked_tmp = tmp.path().join("out.json.tmp");
+        assert!(
+            !leaked_tmp.exists(),
+            "temp file leaked after successful rename: {}",
+            leaked_tmp.display()
+        );
+    }
+
+    #[test]
+    fn hash_bake_handles_output_already_named_dot_tmp() {
+        // Regression: `with_extension("tmp")` would have collided here,
+        // since the output path already ends in `.tmp`. Appending `.tmp`
+        // produces `out.tmp.tmp`, which is distinct and preserves the
+        // atomic guarantee.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let in_path = tmp.path().join("in.json");
+        let out_path = tmp.path().join("out.tmp");
+        fs::write(&in_path, placeholder_g2_bytes()).unwrap();
+
+        let code = cmd_hash_bake(&in_path, &out_path, false);
+        assert_eq!(code, EXIT_OK);
+        assert!(out_path.exists(), "output not created");
+        let baked: PeriodicReport = serde_json::from_slice(&fs::read(&out_path).unwrap()).unwrap();
+        assert_eq!(
+            baked.integrity.content_hash,
+            compute_content_hash(&baked).unwrap()
+        );
     }
 
     #[test]
@@ -226,11 +304,8 @@ mod tests {
     fn hash_bake_input_error_on_missing_file() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let out_path = tmp.path().join("out.json");
-        let code = cmd_hash_bake(
-            Path::new("/nonexistent/path/to/missing.json"),
-            &out_path,
-            false,
-        );
+        let missing = tmp.path().join("does-not-exist.json");
+        let code = cmd_hash_bake(&missing, &out_path, false);
         assert_eq!(code, EXIT_INPUT_ERROR);
     }
 
@@ -243,5 +318,42 @@ mod tests {
 
         let code = cmd_hash_bake(&in_path, &out_path, false);
         assert_eq!(code, EXIT_INPUT_ERROR);
+    }
+
+    #[test]
+    fn hash_bake_input_error_on_oversized_report() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let in_path = tmp.path().join("huge.json");
+        let out_path = tmp.path().join("out.json");
+        // Reserve a virtual file just over the cap. `set_len` extends
+        // sparsely on every supported filesystem, so the bytes are not
+        // actually written.
+        let file = fs::File::create(&in_path).unwrap();
+        file.set_len(MAX_REPORT_BYTES + 1).unwrap();
+        drop(file);
+
+        let code = cmd_hash_bake(&in_path, &out_path, false);
+        assert_eq!(code, EXIT_INPUT_ERROR);
+        assert!(!out_path.exists());
+    }
+
+    #[test]
+    fn hash_bake_input_error_when_temp_path_already_exists() {
+        // Pre-existing `<output>.tmp` (stale or hostile) must abort the
+        // bake instead of being silently truncated. Guards against the
+        // symlink-clobber attack on shared workspaces.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let in_path = tmp.path().join("in.json");
+        let out_path = tmp.path().join("out.json");
+        let collision = tmp.path().join("out.json.tmp");
+        fs::write(&in_path, placeholder_g2_bytes()).unwrap();
+        fs::write(&collision, b"stale").unwrap();
+
+        let code = cmd_hash_bake(&in_path, &out_path, false);
+        assert_eq!(code, EXIT_INPUT_ERROR);
+        assert!(!out_path.exists(), "output must not be created");
+        // The collision file is untouched; the operator can inspect or
+        // remove it themselves.
+        assert_eq!(fs::read(&collision).unwrap(), b"stale");
     }
 }

--- a/crates/sentinel-cli/src/hash_bake.rs
+++ b/crates/sentinel-cli/src/hash_bake.rs
@@ -26,27 +26,23 @@ use std::path::{Path, PathBuf};
 use sentinel_core::report::periodic::{compute_content_hash, schema::PeriodicReport};
 use sentinel_core::text_safety::sanitize_for_terminal;
 
+use crate::limits::MAX_LOCAL_REPORT_BYTES;
+
 pub const EXIT_OK: i32 = 0;
 pub const EXIT_REFUSED: i32 = 1;
 pub const EXIT_INPUT_ERROR: i32 = 3;
-
-// Hard cap on the input report size. Legitimate periodic disclosures
-// are well under 10 MB, 64 MiB leaves room for outliers (deep G1
-// archives, large per-service breakdowns) while bounding the
-// allocation a single CLI invocation will perform.
-const MAX_REPORT_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Entry point invoked from `main.rs` dispatch.
 pub fn cmd_hash_bake(report_path: &Path, output_path: &Path, allow_signed: bool) -> i32 {
     // Refuse oversized inputs before allocating to bound the worst
     // case (poisoned mirror feeding a multi-GB JSON to a CI runner).
     match fs::metadata(report_path) {
-        Ok(meta) if meta.len() > MAX_REPORT_BYTES => {
+        Ok(meta) if meta.len() > MAX_LOCAL_REPORT_BYTES => {
             eprintln!(
                 "Error: report at {} is {} bytes, exceeds the {}-byte cap.",
                 sanitize_for_terminal(&report_path.display().to_string()),
                 meta.len(),
-                MAX_REPORT_BYTES
+                MAX_LOCAL_REPORT_BYTES
             );
             return EXIT_INPUT_ERROR;
         }
@@ -329,7 +325,7 @@ mod tests {
         // sparsely on every supported filesystem, so the bytes are not
         // actually written.
         let file = fs::File::create(&in_path).unwrap();
-        file.set_len(MAX_REPORT_BYTES + 1).unwrap();
+        file.set_len(MAX_LOCAL_REPORT_BYTES + 1).unwrap();
         drop(file);
 
         let code = cmd_hash_bake(&in_path, &out_path, false);

--- a/crates/sentinel-cli/src/hash_bake.rs
+++ b/crates/sentinel-cli/src/hash_bake.rs
@@ -1,0 +1,247 @@
+//! `perf-sentinel hash-bake` subcommand.
+//!
+//! Reads a `PeriodicReport` JSON file, computes the canonical SHA-256
+//! `content_hash` via `sentinel_core::report::periodic::compute_content_hash`,
+//! writes it into `integrity.content_hash`, and saves the report back
+//! atomically. Intended for test fixture generation and debugging when a
+//! report's hash has drifted from canonical.
+//!
+//! Exit codes:
+//!
+//! - `0` success
+//! - `1` refused (`integrity.signature` already populated and
+//!   `--allow-signed` not passed)
+//! - `3` `INPUT_ERROR` (read failure, JSON parse error, write failure)
+
+use std::fs;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use sentinel_core::report::periodic::{compute_content_hash, schema::PeriodicReport};
+use sentinel_core::text_safety::sanitize_for_terminal;
+
+pub const EXIT_OK: i32 = 0;
+pub const EXIT_REFUSED: i32 = 1;
+pub const EXIT_INPUT_ERROR: i32 = 3;
+
+/// Entry point invoked from `main.rs` dispatch.
+pub fn cmd_hash_bake(report_path: &Path, output_path: &Path, allow_signed: bool) -> i32 {
+    let bytes = match fs::read(report_path) {
+        Ok(b) => b,
+        Err(err) => {
+            eprintln!(
+                "Error: failed to read report at {}: {err}",
+                sanitize_for_terminal(&report_path.display().to_string())
+            );
+            return EXIT_INPUT_ERROR;
+        }
+    };
+
+    let mut report: PeriodicReport = match serde_json::from_slice(&bytes) {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!(
+                "Error: failed to parse report at {}: {err}",
+                sanitize_for_terminal(&report_path.display().to_string())
+            );
+            return EXIT_INPUT_ERROR;
+        }
+    };
+
+    if report.integrity.signature.is_some() && !allow_signed {
+        eprintln!(
+            "Error: report at {} already has integrity.signature populated.",
+            sanitize_for_terminal(&report_path.display().to_string())
+        );
+        eprintln!(
+            "Re-baking would not invalidate the signature (content_hash blanches signature in canonical form), but you should confirm the intent."
+        );
+        eprintln!("Pass --allow-signed to proceed.");
+        return EXIT_REFUSED;
+    }
+
+    let hash = match compute_content_hash(&report) {
+        Ok(h) => h,
+        Err(err) => {
+            eprintln!("Error: failed to compute content hash: {err}");
+            return EXIT_INPUT_ERROR;
+        }
+    };
+    report.integrity.content_hash.clone_from(&hash);
+
+    if let Err(code) = write_atomic_pretty(&report, output_path) {
+        return code;
+    }
+
+    println!("Content hash baked: {hash}");
+    println!(
+        "Written to: {}",
+        sanitize_for_terminal(&output_path.display().to_string())
+    );
+    EXIT_OK
+}
+
+// Write `report` to `output` atomically via a sibling `.tmp` file and
+// `rename`. Cleans up the temp on rename failure (best effort).
+fn write_atomic_pretty(report: &PeriodicReport, output: &Path) -> Result<(), i32> {
+    let tmp = output.with_extension("tmp");
+    let file = match fs::File::create(&tmp) {
+        Ok(f) => f,
+        Err(err) => {
+            eprintln!(
+                "Error: failed to create temp file at {}: {err}",
+                sanitize_for_terminal(&tmp.display().to_string())
+            );
+            return Err(EXIT_INPUT_ERROR);
+        }
+    };
+    let mut writer = BufWriter::new(file);
+    if let Err(err) = serde_json::to_writer_pretty(&mut writer, report) {
+        eprintln!("Error: failed to serialize report: {err}");
+        let _ = fs::remove_file(&tmp);
+        return Err(EXIT_INPUT_ERROR);
+    }
+    if let Err(err) = writer.write_all(b"\n") {
+        eprintln!("Error: failed to write trailing newline: {err}");
+        let _ = fs::remove_file(&tmp);
+        return Err(EXIT_INPUT_ERROR);
+    }
+    if let Err(err) = writer.flush() {
+        eprintln!("Error: failed to flush temp file: {err}");
+        let _ = fs::remove_file(&tmp);
+        return Err(EXIT_INPUT_ERROR);
+    }
+    drop(writer);
+    if let Err(err) = fs::rename(&tmp, output) {
+        eprintln!(
+            "Error: failed to rename temp file to {}: {err}",
+            sanitize_for_terminal(&output.display().to_string())
+        );
+        let _ = fs::remove_file(&tmp);
+        return Err(EXIT_INPUT_ERROR);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sentinel_core::report::periodic::schema::SignatureMetadata;
+    use std::path::PathBuf;
+
+    fn workspace_doc(rel: &str) -> PathBuf {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        PathBuf::from(manifest_dir).join("..").join("..").join(rel)
+    }
+
+    fn placeholder_g2_bytes() -> Vec<u8> {
+        fs::read(workspace_doc(
+            "docs/schemas/examples/example-official-public-G2.json",
+        ))
+        .expect("read G2 example")
+    }
+
+    fn dummy_signature() -> SignatureMetadata {
+        SignatureMetadata {
+            format: "sigstore-cosign-intoto-v1".to_string(),
+            bundle_url: "https://example.invalid/x.sig".to_string(),
+            signer_identity: "user@example.invalid".to_string(),
+            signer_issuer: "https://accounts.google.com".to_string(),
+            rekor_url: "https://rekor.sigstore.dev".to_string(),
+            rekor_log_index: 1,
+            signed_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn hash_bake_writes_canonical_hash_on_unsigned_report() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let in_path = tmp.path().join("in.json");
+        let out_path = tmp.path().join("out.json");
+        fs::write(&in_path, placeholder_g2_bytes()).unwrap();
+
+        let code = cmd_hash_bake(&in_path, &out_path, false);
+        assert_eq!(code, EXIT_OK);
+
+        let baked_bytes = fs::read(&out_path).unwrap();
+        let baked: PeriodicReport = serde_json::from_slice(&baked_bytes).unwrap();
+        let recomputed = compute_content_hash(&baked).unwrap();
+        assert_eq!(baked.integrity.content_hash, recomputed);
+        let zero_placeholder = format!("sha256:{}", "0".repeat(64));
+        assert_ne!(baked.integrity.content_hash, zero_placeholder);
+    }
+
+    #[test]
+    fn hash_bake_in_place_works() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("report.json");
+        fs::write(&path, placeholder_g2_bytes()).unwrap();
+
+        let code = cmd_hash_bake(&path, &path, false);
+        assert_eq!(code, EXIT_OK);
+
+        let baked: PeriodicReport = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        let recomputed = compute_content_hash(&baked).unwrap();
+        assert_eq!(baked.integrity.content_hash, recomputed);
+    }
+
+    #[test]
+    fn hash_bake_refuses_signed_report_without_flag() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let in_path = tmp.path().join("in.json");
+        let out_path = tmp.path().join("out.json");
+        let mut report: PeriodicReport = serde_json::from_slice(&placeholder_g2_bytes()).unwrap();
+        report.integrity.signature = Some(dummy_signature());
+        fs::write(&in_path, serde_json::to_vec_pretty(&report).unwrap()).unwrap();
+
+        let code = cmd_hash_bake(&in_path, &out_path, false);
+        assert_eq!(code, EXIT_REFUSED);
+        assert!(
+            !out_path.exists(),
+            "refused bake must not create output file"
+        );
+    }
+
+    #[test]
+    fn hash_bake_accepts_signed_report_with_allow_signed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let in_path = tmp.path().join("in.json");
+        let out_path = tmp.path().join("out.json");
+        let mut report: PeriodicReport = serde_json::from_slice(&placeholder_g2_bytes()).unwrap();
+        report.integrity.signature = Some(dummy_signature());
+        let expected_hash = compute_content_hash(&report).unwrap();
+        fs::write(&in_path, serde_json::to_vec_pretty(&report).unwrap()).unwrap();
+
+        let code = cmd_hash_bake(&in_path, &out_path, true);
+        assert_eq!(code, EXIT_OK);
+        let baked: PeriodicReport = serde_json::from_slice(&fs::read(&out_path).unwrap()).unwrap();
+        // POST_SIGN_FIELDS blanching means the signature does not affect
+        // the canonical hash, so the written value must match the
+        // pre-bake computation.
+        assert_eq!(baked.integrity.content_hash, expected_hash);
+        assert!(baked.integrity.signature.is_some());
+    }
+
+    #[test]
+    fn hash_bake_input_error_on_missing_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let out_path = tmp.path().join("out.json");
+        let code = cmd_hash_bake(
+            Path::new("/nonexistent/path/to/missing.json"),
+            &out_path,
+            false,
+        );
+        assert_eq!(code, EXIT_INPUT_ERROR);
+    }
+
+    #[test]
+    fn hash_bake_input_error_on_invalid_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let in_path = tmp.path().join("in.json");
+        let out_path = tmp.path().join("out.json");
+        fs::write(&in_path, b"not json").unwrap();
+
+        let code = cmd_hash_bake(&in_path, &out_path, false);
+        assert_eq!(code, EXIT_INPUT_ERROR);
+    }
+}

--- a/crates/sentinel-cli/src/hash_bake.rs
+++ b/crates/sentinel-cli/src/hash_bake.rs
@@ -114,7 +114,7 @@ pub fn cmd_hash_bake(report_path: &Path, output_path: &Path, allow_signed: bool)
 }
 
 // Write `report` to `output` atomically via a sibling `.tmp` file and
-// `rename`. Cleans up the temp on rename failure (best effort).
+// `rename`. Each post-open failure removes the temp best-effort.
 fn write_atomic_pretty(report: &PeriodicReport, output: &Path) -> Result<(), i32> {
     // Append `.tmp` instead of replacing the extension so a path like
     // `report.tmp` (whose extension is already `tmp`) does not collide
@@ -293,9 +293,9 @@ mod tests {
         let code = cmd_hash_bake(&in_path, &out_path, true);
         assert_eq!(code, EXIT_OK);
         let baked: PeriodicReport = serde_json::from_slice(&fs::read(&out_path).unwrap()).unwrap();
-        // POST_SIGN_FIELDS blanching means the signature does not affect
-        // the canonical hash, so the written value must match the
-        // pre-bake computation.
+        // The signature-stable canonicalization blanks integrity.signature,
+        // so the canonical hash is identical before and after baking a
+        // signed report.
         assert_eq!(baked.integrity.content_hash, expected_hash);
         assert!(baked.integrity.signature.is_some());
     }

--- a/crates/sentinel-cli/src/limits.rs
+++ b/crates/sentinel-cli/src/limits.rs
@@ -1,0 +1,8 @@
+//! Operational thresholds shared by multiple CLI subcommands.
+
+/// Hard cap on a local `--report` file read. Legitimate periodic
+/// disclosures are well under 10 MB; 64 MiB leaves room for outliers
+/// (deep G1 archives, large per-service breakdowns) while bounding a
+/// single `Vec<u8>` allocation against a poisoned mirror or a runaway
+/// artefact feeding the binary multi-GB JSON.
+pub const MAX_LOCAL_REPORT_BYTES: u64 = 64 * 1024 * 1024;

--- a/crates/sentinel-cli/src/main.rs
+++ b/crates/sentinel-cli/src/main.rs
@@ -13,6 +13,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(feature = "daemon")]
 mod ack;
 mod disclose;
+mod hash_bake;
 #[cfg(feature = "daemon")]
 mod query;
 mod render;
@@ -566,6 +567,30 @@ enum Commands {
         #[arg(long)]
         no_identity_check: bool,
     },
+    /// Compute and bake the canonical `content_hash` into a periodic report.
+    ///
+    /// Reads `--report`, recomputes the canonical SHA-256 `content_hash`
+    /// (applying the `POST_SIGN_FIELDS` blanching that defines the
+    /// signature-stable form), writes it into `integrity.content_hash`,
+    /// and saves the result to `--output`. The same path as `--report`
+    /// is allowed and bakes in place via an atomic temp+rename.
+    /// Intended for test fixture generation and debugging.
+    HashBake {
+        /// Local report file to read.
+        #[arg(long, value_name = "PATH")]
+        report: PathBuf,
+        /// Path to write the report with baked `content_hash`. May
+        /// equal `--report` for in-place baking.
+        #[arg(long, value_name = "PATH")]
+        output: PathBuf,
+        /// Allow re-baking a report whose `integrity.signature` is
+        /// already populated. Re-baking does not invalidate the
+        /// signature (`content_hash` blanches signature in canonical
+        /// form), but the default refusal guards against unintended
+        /// rewrites of signed reports.
+        #[arg(long)]
+        allow_signed: bool,
+    },
 }
 
 /// Output format for query sub-actions.
@@ -931,6 +956,14 @@ async fn dispatch_command(command: Commands) {
                 format,
                 &identity,
             );
+            std::process::exit(code);
+        }
+        Commands::HashBake {
+            report,
+            output,
+            allow_signed,
+        } => {
+            let code = hash_bake::cmd_hash_bake(&report, &output, allow_signed);
             std::process::exit(code);
         }
     }

--- a/crates/sentinel-cli/src/main.rs
+++ b/crates/sentinel-cli/src/main.rs
@@ -570,11 +570,11 @@ enum Commands {
     /// Compute and bake the canonical `content_hash` into a periodic report.
     ///
     /// Reads `--report`, recomputes the canonical SHA-256 `content_hash`
-    /// (applying the `POST_SIGN_FIELDS` blanching that defines the
-    /// signature-stable form), writes it into `integrity.content_hash`,
-    /// and saves the result to `--output`. The same path as `--report`
-    /// is allowed and bakes in place via an atomic temp+rename.
-    /// Intended for test fixture generation and debugging.
+    /// using the same signature-stable canonicalization rules that
+    /// `disclose` applies, writes it into `integrity.content_hash`, and
+    /// saves the result to `--output`. The same path as `--report` is
+    /// allowed and bakes in place via an atomic temp+rename. Intended
+    /// for test fixture generation and debugging.
     HashBake {
         /// Local report file to read.
         #[arg(long, value_name = "PATH")]

--- a/crates/sentinel-cli/src/main.rs
+++ b/crates/sentinel-cli/src/main.rs
@@ -14,6 +14,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 mod ack;
 mod disclose;
 mod hash_bake;
+mod limits;
 #[cfg(feature = "daemon")]
 mod query;
 mod render;

--- a/crates/sentinel-cli/src/verify_hash.rs
+++ b/crates/sentinel-cli/src/verify_hash.rs
@@ -29,15 +29,11 @@ use std::time::Duration;
 use sentinel_core::report::periodic::compute_content_hash;
 use sentinel_core::report::periodic::schema::{IntegrityLevel, PeriodicReport, SignatureMetadata};
 
+use crate::limits::MAX_LOCAL_REPORT_BYTES;
+
 /// Hard cap on remote payloads pulled by `--url`. 10 MB is well above any
 /// realistic report file size and guards against pathological responses.
 const MAX_REMOTE_BYTES: usize = 10 * 1024 * 1024;
-
-/// Hard cap on `--report` local file size. Looser than `MAX_REMOTE_BYTES`
-/// since the operator chose the path, but bounded so a poisoned mirror or a
-/// runaway artefact does not OOM the host through a single `fs::read`
-/// allocation. Mirrors the cap applied by `hash-bake`.
-const MAX_LOCAL_REPORT_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Per-request timeout for `--url` fetches.
 const REMOTE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -150,24 +146,33 @@ fn load_report(
 ) -> Result<(PeriodicReport, String, FetchedPaths), i32> {
     if let Some(path) = report_path {
         let meta = std::fs::metadata(path).map_err(|e| {
-            eprintln!("Error: stat {}: {e}", path.display());
+            eprintln!(
+                "Error: stat {}: {e}",
+                sanitise_for_terminal(&path.display().to_string())
+            );
             EXIT_INPUT_ERROR
         })?;
         if meta.len() > MAX_LOCAL_REPORT_BYTES {
             eprintln!(
-                "Error: report at {} is {} bytes, exceeds the {}-byte cap",
-                path.display(),
+                "Error: report at {} is {} bytes, exceeds the {}-byte cap.",
+                sanitise_for_terminal(&path.display().to_string()),
                 meta.len(),
                 MAX_LOCAL_REPORT_BYTES
             );
             return Err(EXIT_INPUT_ERROR);
         }
         let bytes = std::fs::read(path).map_err(|e| {
-            eprintln!("Error: read {}: {e}", path.display());
+            eprintln!(
+                "Error: read {}: {e}",
+                sanitise_for_terminal(&path.display().to_string())
+            );
             EXIT_INPUT_ERROR
         })?;
         let report = parse_report(&bytes).map_err(|e| {
-            eprintln!("Error: parse {}: {e}", path.display());
+            eprintln!(
+                "Error: parse {}: {e}",
+                sanitise_for_terminal(&path.display().to_string())
+            );
             EXIT_INPUT_ERROR
         })?;
         let display = path.display().to_string();

--- a/crates/sentinel-cli/src/verify_hash.rs
+++ b/crates/sentinel-cli/src/verify_hash.rs
@@ -33,6 +33,12 @@ use sentinel_core::report::periodic::schema::{IntegrityLevel, PeriodicReport, Si
 /// realistic report file size and guards against pathological responses.
 const MAX_REMOTE_BYTES: usize = 10 * 1024 * 1024;
 
+/// Hard cap on `--report` local file size. Looser than `MAX_REMOTE_BYTES`
+/// since the operator chose the path, but bounded so a poisoned mirror or a
+/// runaway artefact does not OOM the host through a single `fs::read`
+/// allocation. Mirrors the cap applied by `hash-bake`.
+const MAX_LOCAL_REPORT_BYTES: u64 = 64 * 1024 * 1024;
+
 /// Per-request timeout for `--url` fetches.
 const REMOTE_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -143,6 +149,19 @@ fn load_report(
     url: Option<&str>,
 ) -> Result<(PeriodicReport, String, FetchedPaths), i32> {
     if let Some(path) = report_path {
+        let meta = std::fs::metadata(path).map_err(|e| {
+            eprintln!("Error: stat {}: {e}", path.display());
+            EXIT_INPUT_ERROR
+        })?;
+        if meta.len() > MAX_LOCAL_REPORT_BYTES {
+            eprintln!(
+                "Error: report at {} is {} bytes, exceeds the {}-byte cap",
+                path.display(),
+                meta.len(),
+                MAX_LOCAL_REPORT_BYTES
+            );
+            return Err(EXIT_INPUT_ERROR);
+        }
         let bytes = std::fs::read(path).map_err(|e| {
             eprintln!("Error: read {}: {e}", path.display());
             EXIT_INPUT_ERROR

--- a/crates/sentinel-cli/tests/hash_bake_e2e.rs
+++ b/crates/sentinel-cli/tests/hash_bake_e2e.rs
@@ -1,0 +1,181 @@
+//! End-to-end integration tests for the `hash-bake` subcommand.
+//!
+//! Exercise the CLI binary end to end (parse, dispatch, write) and
+//! the roundtrip with `verify-hash` that this subcommand was added
+//! to unblock.
+
+use sentinel_core::report::periodic::compute_content_hash;
+use sentinel_core::report::periodic::schema::{PeriodicReport, SignatureMetadata};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_doc(rel: &str) -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest_dir).join("..").join("..").join(rel)
+}
+
+fn run_bake(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_perf-sentinel"))
+        .arg("hash-bake")
+        .args(args)
+        .output()
+        .expect("spawn perf-sentinel hash-bake")
+}
+
+fn run_verify(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_perf-sentinel"))
+        .arg("verify-hash")
+        .args(args)
+        .output()
+        .expect("spawn perf-sentinel verify-hash")
+}
+
+fn copy_g2(dir: &std::path::Path) -> PathBuf {
+    let example = workspace_doc("docs/schemas/examples/example-official-public-G2.json");
+    let dest = dir.join("in.json");
+    fs::write(&dest, fs::read(&example).unwrap()).unwrap();
+    dest
+}
+
+fn dummy_signature() -> SignatureMetadata {
+    SignatureMetadata {
+        format: "sigstore-cosign-intoto-v1".to_string(),
+        bundle_url: "https://example.invalid/x.sig".to_string(),
+        signer_identity: "user@example.invalid".to_string(),
+        signer_issuer: "https://accounts.google.com".to_string(),
+        rekor_url: "https://rekor.sigstore.dev".to_string(),
+        rekor_log_index: 1,
+        signed_at: "2026-01-01T00:00:00Z".to_string(),
+    }
+}
+
+#[test]
+fn hash_bake_writes_canonical_hash_matching_in_process_api() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let in_path = copy_g2(tmp.path());
+    let out_path = tmp.path().join("out.json");
+
+    let out = run_bake(&[
+        "--report",
+        in_path.to_str().unwrap(),
+        "--output",
+        out_path.to_str().unwrap(),
+    ]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let baked: PeriodicReport = serde_json::from_slice(&fs::read(&out_path).unwrap()).unwrap();
+    let recomputed = compute_content_hash(&baked).unwrap();
+    assert_eq!(baked.integrity.content_hash, recomputed);
+    let zero_placeholder = format!("sha256:{}", "0".repeat(64));
+    assert_ne!(baked.integrity.content_hash, zero_placeholder);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Content hash baked:"), "stdout: {stdout}");
+}
+
+#[test]
+fn hash_bake_then_verify_hash_returns_partial_exit_2() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let in_path = copy_g2(tmp.path());
+    let out_path = tmp.path().join("baked.json");
+
+    let bake = run_bake(&[
+        "--report",
+        in_path.to_str().unwrap(),
+        "--output",
+        out_path.to_str().unwrap(),
+    ]);
+    assert_eq!(bake.status.code(), Some(0));
+
+    let verify = run_verify(&["--report", out_path.to_str().unwrap()]);
+    assert_eq!(
+        verify.status.code(),
+        Some(2),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&verify.stdout),
+        String::from_utf8_lossy(&verify.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&verify.stdout);
+    assert!(stdout.contains("[OK] Content hash"), "{stdout}");
+    assert!(stdout.contains("PARTIAL"), "{stdout}");
+}
+
+#[test]
+fn hash_bake_refuses_signed_report_without_flag_e2e() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let in_path = tmp.path().join("signed.json");
+    let out_path = tmp.path().join("out.json");
+    let mut report: PeriodicReport = serde_json::from_slice(
+        &fs::read(workspace_doc(
+            "docs/schemas/examples/example-official-public-G2.json",
+        ))
+        .unwrap(),
+    )
+    .unwrap();
+    report.integrity.signature = Some(dummy_signature());
+    fs::write(&in_path, serde_json::to_vec_pretty(&report).unwrap()).unwrap();
+
+    let out = run_bake(&[
+        "--report",
+        in_path.to_str().unwrap(),
+        "--output",
+        out_path.to_str().unwrap(),
+    ]);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(!out_path.exists(), "refused bake must not create output");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("already has integrity.signature populated"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn hash_bake_in_place_then_verify_hash_partial() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = copy_g2(tmp.path());
+
+    let bake = run_bake(&[
+        "--report",
+        path.to_str().unwrap(),
+        "--output",
+        path.to_str().unwrap(),
+    ]);
+    assert_eq!(
+        bake.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&bake.stderr)
+    );
+
+    let verify = run_verify(&["--report", path.to_str().unwrap()]);
+    assert_eq!(verify.status.code(), Some(2));
+}
+
+#[test]
+fn hash_bake_after_tamper_fails_verify() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let in_path = copy_g2(tmp.path());
+    let baked = tmp.path().join("baked.json");
+
+    let bake = run_bake(&[
+        "--report",
+        in_path.to_str().unwrap(),
+        "--output",
+        baked.to_str().unwrap(),
+    ]);
+    assert_eq!(bake.status.code(), Some(0));
+
+    let bytes = fs::read_to_string(&baked).unwrap();
+    let mutated = bytes.replace("\"Example SAS\"", "\"Tampered SAS\"");
+    assert_ne!(bytes, mutated, "tamper string must be present in fixture");
+    fs::write(&baked, mutated).unwrap();
+
+    let verify = run_verify(&["--report", baked.to_str().unwrap()]);
+    assert_eq!(verify.status.code(), Some(1));
+}

--- a/crates/sentinel-cli/tests/verify_hash_e2e.rs
+++ b/crates/sentinel-cli/tests/verify_hash_e2e.rs
@@ -126,3 +126,18 @@ fn verify_hash_url_mode_rejects_http_scheme() {
     let v = run_verify(&["--url", "http://example.fr/report.json"]);
     assert_eq!(v.status.code(), Some(4));
 }
+
+#[test]
+fn verify_hash_local_report_over_size_cap_returns_input_error() {
+    // 64 MiB cap on `--report <local>`. Sparse `set_len` extends without
+    // writing the bytes so the test runs fast on every filesystem.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let huge = tmp.path().join("huge.json");
+    let file = fs::File::create(&huge).unwrap();
+    file.set_len(64 * 1024 * 1024 + 1).unwrap();
+    drop(file);
+    let v = run_verify(&["--report", huge.to_str().unwrap()]);
+    assert_eq!(v.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&v.stderr);
+    assert!(stderr.contains("exceeds"), "stderr: {stderr}");
+}

--- a/crates/sentinel-cli/tests/verify_hash_e2e.rs
+++ b/crates/sentinel-cli/tests/verify_hash_e2e.rs
@@ -131,6 +131,10 @@ fn verify_hash_url_mode_rejects_http_scheme() {
 fn verify_hash_local_report_over_size_cap_returns_input_error() {
     // 64 MiB cap on `--report <local>`. Sparse `set_len` extends without
     // writing the bytes so the test runs fast on every filesystem.
+    // Source of truth: `crates/sentinel-cli/src/limits.rs::MAX_LOCAL_REPORT_BYTES`.
+    // Kept as a literal here because `perf-sentinel` is a pure binary
+    // crate without a `lib.rs` re-export. Bump in lockstep when the cap
+    // changes.
     let tmp = tempfile::tempdir().expect("tempdir");
     let huge = tmp.path().join("huge.json");
     let file = fs::File::create(&huge).unwrap();

--- a/crates/sentinel-core/src/config.rs
+++ b/crates/sentinel-core/src/config.rs
@@ -1333,9 +1333,17 @@ fn warn_outside_comfort_zone<T>(
     }
 }
 
-/// `true` if `s` contains any ASCII control character (< 0x20 or DEL).
+/// `true` if `s` contains any terminal control character: C0 (`< 0x20`),
+/// DEL (`0x7F`), or C1 (`0x80..=0x9F`). The C1 range carries the single-byte
+/// CSI (`U+009B`), ST (`U+009C`) and OSC (`U+009D`) introducers honoured by
+/// VT-family terminals when 8-bit controls are enabled, so a TOML field that
+/// reaches `tracing::warn!` on stderr must reject them at load time the same
+/// way [`crate::text_safety::sanitize_for_terminal`] rejects them at render.
 pub(crate) fn has_control_char(s: &str) -> bool {
-    s.bytes().any(|b| b < 0x20 || b == 0x7F)
+    s.chars().any(|c| {
+        let code = c as u32;
+        code < 0x20 || code == 0x7F || (0x80..=0x9F).contains(&code)
+    })
 }
 
 /// Validate the wildcard-mode interactions of `[daemon.cors] allowed_origins`.
@@ -3910,6 +3918,22 @@ network_energy_per_byte_kwh = 0.00000000008
         // Embed a tab (0x09) in the host.
         let err = validate_http_authority("http://bad\thost/", "test").unwrap_err();
         assert!(err.contains("control"));
+    }
+
+    #[test]
+    fn has_control_char_rejects_c1_range() {
+        // U+0080..=U+009F survive a byte-level `< 0x20` filter because they
+        // encode as `0xC2 0x80..0x9F` in UTF-8. They carry CSI/ST/OSC in
+        // VT-family terminals, so any TOML field that ends up in stderr
+        // must reject them at load time.
+        assert!(has_control_char("path\u{009b}[31m"));
+        assert!(has_control_char("path\u{009c}suffix"));
+        assert!(has_control_char("path\u{009d}OSC"));
+        // Boundary checks: U+0080 and U+009F are the inclusive endpoints.
+        assert!(has_control_char("\u{0080}"));
+        assert!(has_control_char("\u{009f}"));
+        // U+00A0 (NBSP) sits one past the C1 range and stays allowed.
+        assert!(!has_control_char("\u{00a0}plain"));
     }
 
     #[test]

--- a/crates/sentinel-core/src/text_safety.rs
+++ b/crates/sentinel-core/src/text_safety.rs
@@ -3,20 +3,27 @@
 
 use std::borrow::Cow;
 
-/// Replace ASCII control characters with `?` so an attacker-controlled
-/// string in a JSON `Report` cannot inject ANSI escape sequences,
-/// OSC 8 hyperlinks, cursor controls or other terminal payloads.
+/// True for the control ranges that a terminal can act on: C0 (`0x00..0x20`),
+/// DEL (`0x7f`), and C1 (`0x80..=0x9F`). The C1 set includes the single-byte
+/// CSI (`U+009B`), ST (`U+009C`) and OSC (`U+009D`) introducers honoured by
+/// xterm and other VT-family terminals when 8-bit controls are enabled.
+fn is_dangerous_control(c: char) -> bool {
+    let code = c as u32;
+    code < 0x20 || code == 0x7f || (0x80..=0x9F).contains(&code)
+}
+
+/// Replace control characters with `?` so an attacker-controlled string in a
+/// JSON `Report` cannot inject ANSI escape sequences, OSC 8 hyperlinks, cursor
+/// controls or other terminal payloads. Covers C0, DEL and C1 ranges (see
+/// [`is_dangerous_control`]).
 #[must_use]
 pub fn sanitize_for_terminal(input: &str) -> Cow<'_, str> {
-    if !input.bytes().any(|b| b < 0x20 || b == 0x7f) {
+    if !input.chars().any(is_dangerous_control) {
         return Cow::Borrowed(input);
     }
     let cleaned: String = input
         .chars()
-        .map(|c| {
-            let code = c as u32;
-            if code < 0x20 || code == 0x7f { '?' } else { c }
-        })
+        .map(|c| if is_dangerous_control(c) { '?' } else { c })
         .collect();
     Cow::Owned(cleaned)
 }
@@ -26,7 +33,7 @@ pub fn sanitize_for_terminal(input: &str) -> Cow<'_, str> {
 /// `suggested_fix.reference_url` values planted in a deserialized report.
 #[must_use]
 pub fn safe_url(url: &str) -> Option<&str> {
-    if url.starts_with("https://") && !url.bytes().any(|b| b < 0x20 || b == 0x7f) {
+    if url.starts_with("https://") && !url.chars().any(is_dangerous_control) {
         Some(url)
     } else {
         None
@@ -50,6 +57,21 @@ mod tests {
         let dirty = "a\x1bb\x07c\x00d\x7fe\nf";
         let cleaned = sanitize_for_terminal(dirty);
         assert_eq!(cleaned.as_ref(), "a?b?c?d?e?f");
+    }
+
+    #[test]
+    fn sanitize_replaces_c1_control_range() {
+        // U+0080..=U+009F encodes as `0xC2 0x80..0x9F` in UTF-8 and survives
+        // a byte-level filter that only checks `< 0x20`. xterm with 8-bit
+        // controls enabled honours U+009B (CSI), U+009C (ST), U+009D (OSC).
+        let dirty = "a\u{009b}[31mb\u{009d}OSC\u{009c}c";
+        let cleaned = sanitize_for_terminal(dirty);
+        assert_eq!(cleaned.as_ref(), "a?[31mb?OSC?c");
+    }
+
+    #[test]
+    fn safe_url_rejects_c1_control_chars() {
+        assert_eq!(safe_url("https://a.com/\u{009b}[0m"), None);
     }
 
     #[test]

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -421,7 +421,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.7.1"
+      PERF_SENTINEL_VERSION: "0.7.2"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/FR/CI-FR.md
+++ b/docs/FR/CI-FR.md
@@ -478,7 +478,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.7.1"
+      PERF_SENTINEL_VERSION: "0.7.2"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/FR/REPORTING-FR.md
+++ b/docs/FR/REPORTING-FR.md
@@ -468,7 +468,7 @@ Pour les fixtures de test et les workflows de debug où vous avez besoin d'un ra
 perf-sentinel hash-bake --report input.json --output output.json
 ```
 
-`hash-bake` lit le rapport à `--report`, calcule le `content_hash` canonique (en appliquant le blanching `POST_SIGN_FIELDS` défini pour la version du schema), écrit le hash dans `integrity.content_hash`, et sauvegarde le résultat à `--output`. Le même chemin que `--report` est accepté pour un baking en place, avec un temp+rename atomique qui évite toute corruption partielle.
+`hash-bake` lit le rapport à `--report`, calcule le `content_hash` canonique (en appliquant le blanchiment `POST_SIGN_FIELDS` défini pour la version du schéma), écrit le hash dans `integrity.content_hash`, et sauvegarde le résultat à `--output`. Le même chemin que `--report` est accepté pour un baking en place, avec un temp+rename atomique qui évite toute corruption partielle.
 
 Cette commande est destinée à :
 
@@ -483,7 +483,7 @@ Codes de sortie :
 
 | Code | Signification                                                                                                 |
 |------|---------------------------------------------------------------------------------------------------------------|
-| 0    | Hash baked, fichier écrit.                                                                                    |
+| 0    | Hash canonique calculé, fichier écrit.                                                                        |
 | 1    | Refusé : le rapport porte une signature et `--allow-signed` n'a pas été passé. Aucun fichier de sortie écrit. |
 | 3    | Erreur d'entrée : rapport illisible, JSON invalide, ou écriture impossible.                                   |
 

--- a/docs/FR/REPORTING-FR.md
+++ b/docs/FR/REPORTING-FR.md
@@ -481,11 +481,11 @@ Les rapports signés (`integrity.signature` non-null) sont rejetés par défaut.
 
 Codes de sortie :
 
-| Code | Signification |
-|------|---------------|
-| 0 | Hash baked, fichier écrit. |
-| 1 | Refusé : le rapport porte une signature et `--allow-signed` n'a pas été passé. Aucun fichier de sortie écrit. |
-| 3 | Erreur d'entrée : rapport illisible, JSON invalide, ou écriture impossible. |
+| Code | Signification                                                                                                 |
+|------|---------------------------------------------------------------------------------------------------------------|
+| 0    | Hash baked, fichier écrit.                                                                                    |
+| 1    | Refusé : le rapport porte une signature et `--allow-signed` n'a pas été passé. Aucun fichier de sortie écrit. |
+| 3    | Erreur d'entrée : rapport illisible, JSON invalide, ou écriture impossible.                                   |
 
 ## Erreurs courantes
 

--- a/docs/FR/REPORTING-FR.md
+++ b/docs/FR/REPORTING-FR.md
@@ -460,6 +460,33 @@ Pour un maximum de confiance sur une publication, utiliser le
 binaire de release qui matche le tag déclaré dans
 `integrity.binary_verification_url`.
 
+## Calculer un content hash canonique avec `hash-bake` (0.7.2+)
+
+Pour les fixtures de test et les workflows de debug où vous avez besoin d'un rapport dont le `content_hash` correspond déjà à ce que perf-sentinel produirait, utilisez `hash-bake` :
+
+```bash
+perf-sentinel hash-bake --report input.json --output output.json
+```
+
+`hash-bake` lit le rapport à `--report`, calcule le `content_hash` canonique (en appliquant le blanching `POST_SIGN_FIELDS` défini pour la version du schema), écrit le hash dans `integrity.content_hash`, et sauvegarde le résultat à `--output`. Le même chemin que `--report` est accepté pour un baking en place, avec un temp+rename atomique qui évite toute corruption partielle.
+
+Cette commande est destinée à :
+
+- Générer des fixtures de test avec un hash canonique valide (par exemple pour des suites qui exercent `verify-hash` en sortie TRUSTED ou PARTIAL).
+- Déboguer un rapport dont le hash a divergé du canonique (typiquement après des édits manuels sur des champs hors `POST_SIGN_FIELDS`).
+
+Les rapports signés (`integrity.signature` non-null) sont rejetés par défaut. Le re-baking n'invalide pas la signature, puisque la forme canonique blanchit la signature de toute façon, mais l'opérateur doit confirmer l'intention via `--allow-signed`.
+
+`hash-bake` ne modifie pas `integrity.signature`, ne modifie pas `integrity.binary_attestation`, et ne modifie pas `report_metadata.integrity_level`. Il n'écrit que `integrity.content_hash`.
+
+Codes de sortie :
+
+| Code | Signification |
+|------|---------------|
+| 0 | Hash baked, fichier écrit. |
+| 1 | Refusé : le rapport porte une signature et `--allow-signed` n'a pas été passé. Aucun fichier de sortie écrit. |
+| 3 | Erreur d'entrée : rapport illisible, JSON invalide, ou écriture impossible. |
+
 ## Erreurs courantes
 
 - `Error: audited intent is reserved for a future release, use 'internal' or 'official' instead` : basculer `--intent` sur `internal` ou `official`.

--- a/docs/FR/design/10-SIGSTORE-ATTESTATION-FR.md
+++ b/docs/FR/design/10-SIGSTORE-ATTESTATION-FR.md
@@ -302,6 +302,10 @@ Le verdict global apparaît comme `TRUSTED` (content hash +
 signature OK), `PARTIAL` (content hash OK mais signature
 NotProvided ou Skip), ou `UNTRUSTED` (un FAIL).
 
+## Outillage : `hash-bake`
+
+La sous-commande `hash-bake` (0.7.2+) calcule le `content_hash` canonique d'un rapport et l'écrit dans `integrity.content_hash` sans passer par le pipeline `disclose` complet. Elle existe pour la génération de fixtures de test et pour le debug des rapports dont le hash a divergé du canonique après des édits manuels. Par défaut elle refuse d'opérer sur un rapport portant déjà une `integrity.signature` pour ne pas masquer une erreur de workflow. Voir `docs/FR/REPORTING-FR.md` § "Calculer un content hash canonique avec `hash-bake`" pour la référence côté opérateur.
+
 ## Renvois
 
 - `docs/FR/SCHEMA-FR.md` documente la forme wire de

--- a/docs/REPORTING.md
+++ b/docs/REPORTING.md
@@ -448,6 +448,33 @@ not provided`. The `integrity_level` is `signed`, not
 the released binary matching the tag declared in
 `integrity.binary_verification_url`.
 
+## Computing a canonical content hash with `hash-bake` (0.7.2+)
+
+For test fixtures and debugging workflows where you need a report whose `content_hash` already matches what perf-sentinel itself would write, use `hash-bake`:
+
+```bash
+perf-sentinel hash-bake --report input.json --output output.json
+```
+
+`hash-bake` reads the report at `--report`, computes the canonical `content_hash` (applying the `POST_SIGN_FIELDS` blanching defined for the schema version), writes the hash into `integrity.content_hash`, and saves the result to `--output`. The same path as `--report` is allowed for in-place baking, with an atomic temp+rename that prevents partial corruption.
+
+This command is intended for:
+
+- Generating test fixtures with valid canonical hashes (for example, test suites that exercise `verify-hash` with TRUSTED or PARTIAL outcomes).
+- Debugging a report whose hash has drifted from canonical (typically after manual edits to fields outside `POST_SIGN_FIELDS`).
+
+Signed reports (where `integrity.signature` is non-null) are rejected by default. Re-baking does not invalidate the signature, since the canonical form blanches the signature anyway, but the operator should confirm intent with `--allow-signed`.
+
+`hash-bake` does not modify `integrity.signature`, does not modify `integrity.binary_attestation`, and does not modify `report_metadata.integrity_level`. It only writes `integrity.content_hash`.
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Hash baked, file written. |
+| 1 | Refused: report carries a signature and `--allow-signed` was not passed. No output written. |
+| 3 | Input error: report unreadable, JSON invalid, or output cannot be written. |
+
 ## Common errors
 
 - `Error: audited intent is reserved for a future release, use 'internal' or 'official' instead`: switch `--intent` to `internal` or `official`.

--- a/docs/REPORTING.md
+++ b/docs/REPORTING.md
@@ -469,11 +469,11 @@ Signed reports (where `integrity.signature` is non-null) are rejected by default
 
 Exit codes:
 
-| Code | Meaning |
-|------|---------|
-| 0 | Hash baked, file written. |
-| 1 | Refused: report carries a signature and `--allow-signed` was not passed. No output written. |
-| 3 | Input error: report unreadable, JSON invalid, or output cannot be written. |
+| Code | Meaning                                                                                     |
+|------|---------------------------------------------------------------------------------------------|
+| 0    | Hash baked, file written.                                                                   |
+| 1    | Refused: report carries a signature and `--allow-signed` was not passed. No output written. |
+| 3    | Input error: report unreadable, JSON invalid, or output cannot be written.                  |
 
 ## Common errors
 

--- a/docs/ci-templates/github-actions-baseline.yml
+++ b/docs/ci-templates/github-actions-baseline.yml
@@ -41,7 +41,7 @@ jobs:
     name: Publish trunk baseline to gh-pages
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.7.1"
+      PERF_SENTINEL_VERSION: "0.7.2"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/github-actions.yml
+++ b/docs/ci-templates/github-actions.yml
@@ -58,7 +58,7 @@ jobs:
     name: Performance anti-pattern scan
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.7.1"
+      PERF_SENTINEL_VERSION: "0.7.2"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/gitlab-ci.yml
+++ b/docs/ci-templates/gitlab-ci.yml
@@ -23,7 +23,7 @@ stages:
   - perf-sentinel
 
 variables:
-  PERF_SENTINEL_VERSION: "0.7.1"
+  PERF_SENTINEL_VERSION: "0.7.2"
   PERF_SENTINEL_TRACES: "test-traces.json"
   PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/jenkinsfile.groovy
+++ b/docs/ci-templates/jenkinsfile.groovy
@@ -66,7 +66,7 @@ pipeline {
     }
 
     environment {
-        PERF_SENTINEL_VERSION = '0.7.1'
+        PERF_SENTINEL_VERSION = '0.7.2'
         PERF_SENTINEL_TRACES  = 'target/traces.json'
         PERF_SENTINEL_CONFIG  = '.perf-sentinel.toml'
     }

--- a/docs/design/10-SIGSTORE-ATTESTATION.md
+++ b/docs/design/10-SIGSTORE-ATTESTATION.md
@@ -285,6 +285,10 @@ The overall verdict surfaces as one of `TRUSTED` (content hash +
 signature both OK), `PARTIAL` (content hash OK but signature
 NotProvided or Skip), or `UNTRUSTED` (any FAIL).
 
+## Tooling: `hash-bake`
+
+The `hash-bake` subcommand (0.7.2+) computes the canonical `content_hash` of a report and writes it back into `integrity.content_hash` without going through the full `disclose` pipeline. It exists for test fixture generation and for debugging reports whose hash has drifted from canonical after manual edits. By default it refuses to operate on reports that already carry an `integrity.signature` to avoid masking workflow errors. See `docs/REPORTING.md` § "Computing a canonical content hash with `hash-bake`" for the operator-facing reference.
+
 ## Cross-references
 
 - `docs/SCHEMA.md` documents the on-the-wire shape of

--- a/docs/schemas/examples/example-internal-G1.json
+++ b/docs/schemas/examples/example-internal-G1.json
@@ -168,7 +168,7 @@
   "integrity": {
     "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "binary_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.7.1",
+    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.7.2",
     "trace_integrity_chain": null,
     "signature": null
   },

--- a/docs/schemas/examples/example-official-public-G2.json
+++ b/docs/schemas/examples/example-official-public-G2.json
@@ -131,7 +131,7 @@
   "integrity": {
     "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "binary_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.7.1",
+    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.7.2",
     "trace_integrity_chain": null,
     "signature": null
   },


### PR DESCRIPTION
## Summary

New `perf-sentinel hash-bake` CLI subcommand that reads a `PeriodicReport` JSON file, recomputes the canonical SHA-256 `content_hash` via the existing `compute_content_hash` API, writes the hash into `integrity.content_hash`, and saves the result via an atomic temp+rename. Intended for test fixture generation and for debugging reports whose hash drifted from canonical.

Closes the residual gap in `simulation-lab/scenarios/verify-hash-roundtrip/` where TRUSTED (exit 0) and PARTIAL (exit 2) outcomes could not be exercised E2E because they required an externally-baked canonical hash.

The release also ships several cross-cutting defense-in-depth improvements surfaced by four rounds of cross-agent review.

## Changes

### New feature
- `perf-sentinel hash-bake --report <PATH> --output <PATH> [--allow-signed]`. Exit codes 0 (success), 1 (refused: signed without flag), 3 (input error: unreadable, JSON invalid, over 64 MiB cap, temp file collision, write failure).
- Atomic write via `OpenOptions::create_new(true)` + `O_NOFOLLOW` on unix, refusing pre-existing or symlinked `<output>.tmp`.
- 64 MiB input size cap via `fs::metadata` precheck.

### Security hardening (workspace-wide)
- `sentinel_core::text_safety::sanitize_for_terminal` and `safe_url` now strip the C1 control range `0x80..=0x9F` (CSI `U+009B`, ST `U+009C`, OSC `U+009D`). Workspace-wide impact, every render boundary benefits.
- `sentinel_core::config::has_control_char` extended identically, closing the ANSI injection vector through `tracing::warn!` lines that format TOML-controlled strings.
- `verify-hash --report <local>` now applies the same 64 MiB cap as `hash-bake`, with consistent error wording and path sanitization on every failure path of `load_report`.
- Shared constant `crates/sentinel-cli/src/limits.rs::MAX_LOCAL_REPORT_BYTES` consumed by both subcommands.

### Version bumps
- Workspace: 0.7.1 → 0.7.2 (Cargo.toml, Cargo.lock, intra-pin, 4 ci-templates, docs/CI.md, docs/FR/CI-FR.md, 2 example JSON files).
- Helm chart: 0.2.36 → 0.2.37 (appVersion 0.7.2, artifacthub annotations refreshed, CHANGELOG section added).

### Documentation
- New `## Computing a canonical content hash with hash-bake (0.7.2+)` section in `docs/REPORTING.md` and FR mirror, including the exit code table.
- New `## Tooling: hash-bake` paragraph in `docs/design/10-SIGSTORE-ATTESTATION.md` and FR mirror, framing `hash-bake` as a fixture/debug tool complementing the disclosure pipeline.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` 0 failed (1976+ tests across the workspace)
- [x] Unit tests: 7 in `hash_bake::tests` covering happy path, in-place bake, signed-refused, allow-signed, missing file, invalid JSON, oversized report, temp file collision, dot-tmp edge case
- [x] E2E tests: 5 in `crates/sentinel-cli/tests/hash_bake_e2e.rs` covering CLI roundtrip with verify-hash, signed-refused via CLI exit code, in-place via CLI, tamper detection. +1 in `verify_hash_e2e.rs` covering the new 64 MiB local cap
- [x] +1 test `text_safety::tests::sanitize_replaces_c1_control_range` covering the C1 hardening
- [x] +1 test `text_safety::tests::safe_url_rejects_c1_control_chars`
- [x] +1 test `config::tests::has_control_char_rejects_c1_range` with U+0080/U+009F boundary checks and NBSP U+00A0 preservation
- [x] `bash scripts/check-tag-version.sh v0.7.2` matches
- [x] `bash scripts/check-helm-tag-version.sh chart-v0.2.37` matches
- [x] `bash scripts/check-chart-version-bumped.sh main` confirms 0.2.36 → 0.2.37 with CHANGELOG section present
- [x] Manual smokes on the debug binary: unsigned bake, in-place bake, refused signed, allow-signed accepts, missing file exit 3, oversized 70 MiB file exit 3 with clear message, pre-existing `<output>.tmp` exit 3 with stale file preserved, verify-hash on 70 MiB file exit 3
- [ ] Simulation lab validation (`/Users/robintrassard/IdeaProjects/perf-sentinel-simulation-lab/scenarios/verify-hash-roundtrip/`): expected to close the TRUSTED/PARTIAL coverage gap once 0.7.2 binary is available

## Review history

Four rounds of cross-agent review (rust-reviewer + perf-greenops-reviewer + security-checker, in parallel). Final verdicts: ship as is / audit pass / orthogonal pass. All actionable findings absorbed in `fix(...)` / `refactor(...)` commits with regression tests. Defended out-of-scope items: `CHANGELOG.md` untouched per project convention, `pub` vs `pub(crate)` kept consistent with sibling `verify_hash`, helper duplication between unit and e2e tests deferred to a future `tests/common/` extraction.