### PR TITLE
fix(ci): parse OCI digest from helm push output instead of post-push crane lookup

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -140,11 +140,24 @@ jobs:
 
       - name: Push chart
         id: push
+        # Parse the digest directly from helm push output instead of
+        # calling `crane digest` after the fact. Avoids a race window
+        # against GHCR's eventually-consistent tag index (observed on
+        # chart-v0.2.41 where helm push succeeded but the immediate
+        # `crane digest` returned empty), and removes a second auth
+        # round trip with the registry. Falls back to `crane digest` if
+        # the helm output format ever drifts.
         run: |
-          helm push "out/${{ steps.package.outputs.tarball_name }}" oci://ghcr.io/robintra/charts
-          digest=$(crane digest "ghcr.io/robintra/charts/perf-sentinel:${{ needs.check-chart-version.outputs.chart_version }}")
+          set -o pipefail
+          push_output=$(helm push "out/${{ steps.package.outputs.tarball_name }}" oci://ghcr.io/robintra/charts 2>&1)
+          printf '%s\n' "${push_output}"
+          digest=$(printf '%s\n' "${push_output}" | grep -oE 'sha256:[a-f0-9]{64}' | head -n 1 || true)
           if [ -z "${digest}" ]; then
-            echo "::error::crane digest returned empty for the pushed chart"
+            echo "::warning::helm push output did not surface a digest, falling back to crane digest"
+            digest=$(crane digest "ghcr.io/robintra/charts/perf-sentinel:${{ needs.check-chart-version.outputs.chart_version }}" || true)
+          fi
+          if [ -z "${digest}" ]; then
+            echo "::error::could not extract digest for the pushed chart (helm and crane both empty)"
             exit 1
           fi
           echo "oci_digest=${digest}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Root-cause fix for the chart-v0.2.41 release workflow failure. The \`Push chart\` step in \`.github/workflows/helm-release.yml\` calls \`helm push\` to publish the chart to GHCR, then immediately calls \`crane digest\` to capture the OCI digest for the downstream Cosign sign / SBOM attest / provenance attest / Draft GitHub Release jobs. On chart-v0.2.41 the \`helm push\` succeeded silently (the tag \`0.2.41\` is observable on GHCR with digest \`sha256-8d09fe6...\` via anonymous \`tags/list\`), but \`crane digest\` returned an empty string immediately after, triggered the step's error guard, and stopped the job. All downstream jobs (Cosign, SBOM, provenance, Draft GitHub Release) skipped, the GitHub release \`chart-v0.2.41\` was created manually after the fact with the local tarball and the release notes.

The race condition is real: \`crane digest\` queries GHCR's manifest endpoint, and the tag index is eventually consistent. The chart-v0.2.40 run didn't trip it but chart-v0.2.41 did, with no diff in the workflow YAML between the two runs. A second cause would be \`crane digest\` not recognising helm-chart OCI artifacts (config media type \`application/vnd.cncf.helm.config.v1+json\`) under some crane builds. Either way the dependency on \`crane digest\` for the digest is unnecessary: \`helm push\` already prints the digest on its own output.

## Changes

- Replace the post-push \`crane digest\` call with a parse of \`helm push\` stdout/stderr. Helm prints \`Pushed: ...\` and \`Digest: sha256:...\` on every successful push since helm 3, the regex \`sha256:[a-f0-9]{64}\` extracts it without an extra network round-trip.
- Keep \`crane digest\` as a fallback if the helm output format ever drifts. The warning surfaces explicitly so future runs that hit the fallback path are visible at \`::warning::\` level.
- Hard-fail with a clear error if both helm and crane return empty (preserves the original guard semantics).
- \`set -o pipefail\` so a pipe failure in the digest extraction is not silently swallowed.

No diff to the \`Install crane\` step: crane is no longer the primary path for the digest, but it stays around as fallback and is harmless for the install footprint (one \`curl\` + \`tar\` + \`install\`, < 50 MB on disk).

## Checklist

Cargo:

- [N/A] no Rust diff in this PR

Documentation and assets:

- [N/A] no public-facing doc surface touched
- [N/A] no CLI / TUI / HTML dashboard change
- [N/A] \`CHANGELOG.md\` entry: pure CI fix with no user-facing behaviour change

Versioning (release PRs only):

- [N/A] not a release PR

## Related issues

Follow-up on the chart-v0.2.41 helm-release run [26337675865](https://github.com/robintra/perf-sentinel/actions/runs/26337675865) which failed on the empty-digest guard. The chart binary on GHCR is intact, only the downstream jobs that depend on \`steps.push.outputs.oci_digest\` were affected.