### PR TITLE
chore(chart): bump to 0.2.42 to recover skipped attestations

### DIFF
--- a/charts/perf-sentinel/CHANGELOG.md
+++ b/charts/perf-sentinel/CHANGELOG.md
@@ -6,6 +6,29 @@ Chart versions are independent from the perf-sentinel application
 versions, the chart's `appVersion` field tracks which daemon version is
 the default target.
 
+## [0.2.42]
+
+### Changed
+
+- Re-publication of chart-v0.2.41 to recover the supply-chain attestations
+  that were skipped on the original release. `appVersion` stays at `0.7.6`,
+  template surface is byte-for-byte identical to chart-v0.2.41, the only
+  diff is this `version:` bump and this CHANGELOG entry. The chart-v0.2.41
+  helm-release workflow run succeeded the `helm push` step but tripped on
+  an empty digest returned by `crane digest` immediately after, which
+  stopped the job and skipped the downstream Cosign keyless signature,
+  SPDX SBOM, and SLSA Build L3 provenance attestation jobs. The chart
+  binary was already on GHCR, but operators verifying provenance with
+  `cosign verify` against chart-v0.2.41 fail. chart-v0.2.42 runs the full
+  pipeline against the same template content so the attestations exist
+  for installs going forward. Operators on chart-v0.2.41 can upgrade
+  to chart-v0.2.42 in place, the rendered manifests are identical, no
+  `helm upgrade` migration is needed beyond the chart bump. The
+  workflow regression is fixed in [#33](https://github.com/robintra/perf-sentinel/pull/33),
+  the digest is now parsed from `helm push` output directly instead of
+  a separate `crane digest` call that races against GHCR's
+  eventually-consistent tag index.
+
 ## [0.2.41]
 
 ### Changed

--- a/charts/perf-sentinel/Chart.yaml
+++ b/charts/perf-sentinel/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   pool saturation, serialized parallelizable calls, fanout. Scores I/O
   intensity per endpoint (GreenOps).
 type: application
-version: 0.2.41
+version: 0.2.42
 appVersion: "0.7.6"
 kubeVersion: ">=1.24.0-0"
 home: https://github.com/robintra/perf-sentinel


### PR DESCRIPTION
## Summary

Re-publishes the chart at \`0.2.42\` to recover the Cosign keyless signature, SPDX SBOM, and SLSA Build L3 provenance attestations that were skipped on chart-v0.2.41 (workflow run [26337675865](https://github.com/robintra/perf-sentinel/actions/runs/26337675865) failed on \`crane digest returned empty\` after a successful \`helm push\`, all downstream attestation jobs skipped). The empty-digest race condition is fixed in [#33](https://github.com/robintra/perf-sentinel/pull/33), which is already on \`main\`, so this PR triggers a clean full-pipeline run.

## Changes

- \`charts/perf-sentinel/Chart.yaml\`: \`version: 0.2.41\` → \`0.2.42\`. \`appVersion\` stays at \`0.7.6\`, no daemon bump, no template diff, no \`values.yaml\` schema change.
- \`charts/perf-sentinel/CHANGELOG.md\`: \`[0.2.42]\` entry under \`### Changed\` explaining the re-publication motive and pointing at the workflow fix.

The chart binary uploaded by this PR's release workflow will be byte-for-byte identical to chart-v0.2.41 except for the embedded \`Chart.yaml version:\` field. Operators on chart-v0.2.41 can \`helm upgrade\` to chart-v0.2.42 in place, rendered manifests are identical.

## Checklist

Cargo:

- [N/A] no Rust diff in this PR

Documentation and assets:

- [x] Public-facing docs updated (chart \`CHANGELOG.md\` entry added)
- [N/A] Captures regenerated (no CLI / TUI / HTML dashboard change)
- [N/A] root \`CHANGELOG.md\` entry: chart-only bump, no daemon code touched, and root \`CHANGELOG.md\` is gitignored

Versioning (release PRs only):

- [N/A] \`workspace.package.version\`: chart-only bump, daemon stays at \`0.7.6\`
- [N/A] Intra-workspace pin: unchanged
- [N/A] \`PERF_SENTINEL_VERSION\` in ci-templates: unchanged, daemon stays at \`0.7.6\`
- [x] \`charts/perf-sentinel/Chart.yaml\` bumped (chart version only, appVersion unchanged)
- [x] \`./scripts/check-helm-tag-version.sh chart-v0.2.42\` passes locally
- [x] \`./scripts/check-chart-appversion-annotation.sh\` passes locally

## Related issues

Recovers the chart attestations that were skipped on chart-v0.2.41 due to the workflow regression fixed in [#33](https://github.com/robintra/perf-sentinel/pull/33).