### PR TITLE
Release 0.8.2: canonical and operational disclosure waste tiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,9 +231,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -249,6 +258,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -481,12 +496,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -709,6 +730,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -1324,6 +1351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,7 +1380,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -1388,15 +1421,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
-dependencies = [
- "hashbrown 0.16.1",
-]
 
 [[package]]
 name = "lru"
@@ -1502,7 +1526,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1637,6 +1661,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,7 +1754,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "libc",
- "lru 0.18.0",
+ "lru",
  "opentelemetry-proto",
  "prometheus",
  "prost",
@@ -1904,7 +1952,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "hex",
  "procfs-core",
  "rustix 0.38.44",
@@ -1916,7 +1964,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "hex",
 ]
 
@@ -1943,7 +1991,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "num-traits",
  "rand 0.9.3",
  "rand_chacha",
@@ -2071,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -2081,21 +2129,25 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "compact_str",
- "hashbrown 0.16.1",
+ "critical-section",
+ "hashbrown 0.17.0",
  "indoc",
  "itertools",
  "kasuari",
- "lru 0.16.3",
+ "lru",
+ "palette",
+ "serde",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -2105,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -2117,9 +2169,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -2127,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -2137,17 +2189,18 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.16.1",
+ "bitflags 2.12.1",
+ "hashbrown 0.17.0",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
+ "serde",
  "strum",
  "time",
  "unicode-segmentation",
@@ -2160,7 +2213,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -2253,7 +2306,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2266,7 +2319,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2529,18 +2582,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2635,7 +2688,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -2928,7 +2981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "bytes",
  "futures-core",
  "http",
@@ -3281,7 +3334,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3604,7 +3657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.12.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,7 +1715,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perf-sentinel"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "perf-sentinel-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sentinel-core", "crates/sentinel-cli"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 license = "AGPL-3.0-only"
 rust-version = "1.96.0"

--- a/charts/perf-sentinel/CHANGELOG.md
+++ b/charts/perf-sentinel/CHANGELOG.md
@@ -6,6 +6,13 @@ Chart versions are independent from the perf-sentinel application
 versions, the chart's `appVersion` field tracks which daemon version is
 the default target.
 
+## [0.2.47]
+
+### Changed
+
+- `appVersion` bumped to `0.8.2` to track the two-tier avoidable energy and carbon breakdown added to the periodic public disclosure (a canonical N+1 threshold pinned in the binary that the operator cannot configure, next to the operational threshold, schema v1.1) and the ratatui 0.30.1 TUI backend bump. Template surface is unchanged, no migration needed beyond the chart bump. The report JSON schema gains the additive v1.1 waste tiers, v1.0 consumers are unaffected. No config or daemon wire change.
+- `artifacthub.io/images` annotation bumped to `ghcr.io/robintra/perf-sentinel:0.8.2` to keep the Artifact Hub display metadata in lockstep with `appVersion`. Runtime image selection is unaffected (templates already resolve to `.Chart.AppVersion` when `values.yaml` `image.tag` is empty).
+
 ## [0.2.46]
 
 ### Changed

--- a/charts/perf-sentinel/Chart.yaml
+++ b/charts/perf-sentinel/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   pool saturation, serialized parallelizable calls, fanout. Scores I/O
   intensity per endpoint (GreenOps).
 type: application
-version: 0.2.46
-appVersion: "0.8.1"
+version: 0.2.47
+appVersion: "0.8.2"
 kubeVersion: ">=1.24.0-0"
 home: https://github.com/robintra/perf-sentinel
 icon: https://raw.githubusercontent.com/robintra/perf-sentinel/main/logo/logo-horizontal.svg
@@ -49,9 +49,11 @@ annotations:
       description: "appVersion 0.8.0: the inspect TUI becomes a unified multi-view interface. Two views join the existing Inspect browser, Analyze (GreenOps summary with I/O waste ratio, top offenders, quality gate, findings by severity) and Explain (the selected trace's annotated span tree, full screen). Enter descends Analyze -> Inspect -> Explain and Esc ascends back. analyze --tui and explain --tui open the TUI directly, their default stdout output is unchanged because --tui conflicts with --format and --ci. Under query inspect the Analyze view is fed live from /api/export/report, degrading to a hint on older daemons. No chart template change, this bump only tracks the new appVersion."
     - kind: changed
       description: "appVersion 0.8.1: patch release with no daemon-facing change. The SQL tokenizer slice path gains a debug-only char-boundary assertion (compiled out in release) as a refactor guard, disclose state initialization is simplified, and the release profile rationale now documents why overflow-checks stays off in release. Remaining changes are release tooling (Helm chart release automation script) and documentation. No chart template change, this bump only tracks the new appVersion."
+    - kind: added
+      description: "appVersion 0.8.2: the periodic public disclosure reports avoidable energy and carbon at two N+1 thresholds side by side, canonical_waste (a threshold pinned in the binary that the operator cannot configure, so the disclosed waste figure is non-manipulable) and operational_waste (the operator's configured threshold), schema perf-sentinel-report/v1.1. The flat avoidable fields alias the canonical tier and the change is additive, v1.0 readers remain valid. Also bumps the TUI backend to ratatui 0.30.1. No chart template change, this bump only tracks the new appVersion."
   artifacthub.io/images: |
     - name: perf-sentinel
-      image: ghcr.io/robintra/perf-sentinel:0.8.1
+      image: ghcr.io/robintra/perf-sentinel:0.8.2
       platforms:
         - linux/amd64
         - linux/arm64

--- a/crates/sentinel-cli/Cargo.toml
+++ b/crates/sentinel-cli/Cargo.toml
@@ -39,7 +39,9 @@ tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+# float_roundtrip: exact float parsing so verify-hash round-trips the
+# disclosure content_hash. See the note in sentinel-core/Cargo.toml.
+serde_json = { version = "1.0.149", features = ["float_roundtrip"] }
 # Used to stamp the current time when applying acknowledgments. Same
 # version line as the core crate, default-features off to skip the
 # wasm/JS bindings.
@@ -72,5 +74,5 @@ libc = "0.2.183"
 mimalloc = "0.1.49"
 
 [dev-dependencies]
-serde_json = "1.0.149"
+serde_json = { version = "1.0.149", features = ["float_roundtrip"] }
 tempfile = "3.27.0"

--- a/crates/sentinel-cli/Cargo.toml
+++ b/crates/sentinel-cli/Cargo.toml
@@ -47,7 +47,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # UUID v4 stamped onto every periodic disclosure report. Same pin as the
 # core crate to keep one resolved version in the tree.
 uuid = { version = "1.23.1", features = ["v4"] }
-ratatui = { version = "0.30.0", optional = true }
+ratatui = { version = "0.30.1", optional = true }
 crossterm = { version = "0.29.0", optional = true }
 # Optional, gated behind the `daemon` feature. Used by the
 # `perf-sentinel ack` subcommand to issue POST/DELETE/GET against the

--- a/crates/sentinel-cli/Cargo.toml
+++ b/crates/sentinel-cli/Cargo.toml
@@ -32,7 +32,7 @@ tempo = ["perf-sentinel-core/tempo"]
 jaeger-query = ["perf-sentinel-core/jaeger-query"]
 
 [dependencies]
-perf-sentinel-core = { version = "0.8.1", path = "../sentinel-core" }
+perf-sentinel-core = { version = "0.8.2", path = "../sentinel-core" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap_complete = "4.6.5"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/crates/sentinel-cli/src/main.rs
+++ b/crates/sentinel-cli/src/main.rs
@@ -2577,6 +2577,7 @@ mod tests {
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: String::new(),
+            disclosure_waste: None,
         }
     }
 
@@ -2762,6 +2763,7 @@ mod tests {
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: String::new(),
+            disclosure_waste: None,
         };
         render::format_colored_report(&report, "report", false);
     }

--- a/crates/sentinel-cli/src/main.rs
+++ b/crates/sentinel-cli/src/main.rs
@@ -1083,6 +1083,9 @@ fn resolve_auth_header(
 /// extracted out of the main dispatch so it does not inflate the
 /// match's cognitive complexity.
 #[allow(clippy::too_many_arguments)]
+// The only `.await` is the daemon-gated Prometheus fetch below, so the
+// no-default-features build sees an async fn with no await.
+#[cfg_attr(not(feature = "daemon"), allow(clippy::unused_async))]
 async fn dispatch_pg_stat(
     input: Option<&std::path::Path>,
     #[cfg(feature = "daemon")] prometheus: Option<&str>,
@@ -1570,7 +1573,16 @@ fn load_diff_against_baseline(
     sentinel_core::diff::diff_runs(&baseline, current)
 }
 
-#[allow(clippy::too_many_arguments)] // optional flags, each adds a dedicated ingestion path
+#[allow(clippy::too_many_arguments)]
+// optional flags, each adds a dedicated ingestion path
+// Without the `daemon` feature the only `.await` (the Prometheus pg-stat
+// fetch) is compiled out, leaving an async fn with no await, and the
+// pg_stat `if let`/`else` collapses to a shape clippy reads as `Option::map`
+// even though the `else` carries the daemon-gated Prometheus branch.
+#[cfg_attr(
+    not(feature = "daemon"),
+    allow(clippy::unused_async, clippy::manual_map)
+)]
 async fn cmd_report(
     input: Option<&std::path::Path>,
     config_path: Option<&std::path::Path>,

--- a/crates/sentinel-core/Cargo.toml
+++ b/crates/sentinel-core/Cargo.toml
@@ -31,7 +31,11 @@ jaeger-query = ["dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:bytes"
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive", "rc"] }
-serde_json = "1.0.149"
+# `float_roundtrip`: the disclosure `content_hash` is computed over the
+# serialized JSON, so a float must parse back to the exact same f64 on
+# verify-hash. The default serde_json parser can shift a value by 1 ULP,
+# breaking the hash of an untampered report. This feature makes parsing exact.
+serde_json = { version = "1.0.149", features = ["float_roundtrip"] }
 tracing = "0.1.44"
 thiserror = "2.0.18"
 toml = "1.1.2"

--- a/crates/sentinel-core/src/acknowledgments.rs
+++ b/crates/sentinel-core/src/acknowledgments.rs
@@ -316,6 +316,7 @@ mod tests {
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: String::new(),
+            disclosure_waste: None,
         }
     }
 

--- a/crates/sentinel-core/src/daemon/event_loop.rs
+++ b/crates/sentinel-core/src/daemon/event_loop.rs
@@ -542,6 +542,18 @@ async fn process_traces(
 
     if let Some(handle) = ctx.archive_handle {
         let events_processed = trace_structs.iter().map(|t| t.spans.len()).sum();
+        // Operator + canonical avoidable tiers, archived side by side.
+        // Skipped when green scoring produced no carbon: the tiers would
+        // carry avoidable ops with zero energy/carbon, and the extra
+        // canonical detection pass would be wasted. Computed before the
+        // summary is moved into the report.
+        let disclosure_waste = green_summary.co2.is_some().then(|| {
+            score::canonical::compute_disclosure_waste(
+                &trace_structs,
+                &green_summary,
+                ctx.detect_config,
+            )
+        });
         let report = crate::report::Report {
             analysis: crate::report::Analysis {
                 duration_ms: 0,
@@ -563,6 +575,7 @@ async fn process_traces(
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: env!("CARGO_PKG_VERSION").to_string(),
+            disclosure_waste,
         };
         let archive = super::archive::OwnedArchive {
             ts: chrono::Utc::now(),

--- a/crates/sentinel-core/src/daemon/query_api.rs
+++ b/crates/sentinel-core/src/daemon/query_api.rs
@@ -469,6 +469,7 @@ async fn handle_export_report(State(state): State<Arc<QueryApiState>>) -> Json<R
             )],
             acknowledged_findings: Vec::new(),
             binary_version: env!("CARGO_PKG_VERSION").to_string(),
+            disclosure_waste: None,
         });
     }
 
@@ -555,6 +556,7 @@ async fn handle_export_report(State(state): State<Arc<QueryApiState>>) -> Json<R
         warning_details,
         acknowledged_findings: vec![],
         binary_version: env!("CARGO_PKG_VERSION").to_string(),
+        disclosure_waste: None,
     };
 
     Json(report)

--- a/crates/sentinel-core/src/detect/mod.rs
+++ b/crates/sentinel-core/src/detect/mod.rs
@@ -11,6 +11,8 @@ pub mod serialized;
 pub mod slow;
 pub mod suggestions;
 
+pub use n_plus_one::DISCLOSURE_N_PLUS_ONE_THRESHOLD;
+
 use std::collections::HashMap;
 
 use crate::correlate::Trace;

--- a/crates/sentinel-core/src/detect/n_plus_one.rs
+++ b/crates/sentinel-core/src/detect/n_plus_one.rs
@@ -22,6 +22,13 @@ use super::{ClassificationMethod, Finding, FindingType, Severity};
 /// here automatically updates the CLI interpretation band.
 pub(crate) const CRITICAL_OCCURRENCE_THRESHOLD: usize = 10;
 
+/// Fixed N+1 threshold for the avoidable energy/carbon archived for periodic
+/// disclosure. Not operator-configurable on purpose: sourcing it from config
+/// would let a loose operational threshold shrink the disclosed waste. Value
+/// `2` is the most sensitive defensible threshold, so the figure is an upper
+/// bound the operator cannot reduce.
+pub const DISCLOSURE_N_PLUS_ONE_THRESHOLD: u32 = 2;
+
 /// Detect N+1 patterns in a single trace.
 ///
 /// Groups spans by (`event_type`, template) and emits a finding when the

--- a/crates/sentinel-core/src/diff.rs
+++ b/crates/sentinel-core/src/diff.rs
@@ -292,6 +292,7 @@ mod tests {
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: String::new(),
+            disclosure_waste: None,
         }
     }
 

--- a/crates/sentinel-core/src/pipeline.rs
+++ b/crates/sentinel-core/src/pipeline.rs
@@ -85,6 +85,10 @@ pub fn analyze_with_traces(
         warning_details: vec![],
         acknowledged_findings: vec![],
         binary_version: env!("CARGO_PKG_VERSION").to_string(),
+        // Batch analyze does not feed the periodic disclosure (that path is
+        // daemon-archive-sourced), so the canonical avoidable tiers are only
+        // computed at archive time, not here.
+        disclosure_waste: None,
     };
 
     (report, traces)

--- a/crates/sentinel-core/src/report/html.rs
+++ b/crates/sentinel-core/src/report/html.rs
@@ -679,6 +679,7 @@ mod tests {
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: String::new(),
+            disclosure_waste: None,
         }
     }
 

--- a/crates/sentinel-core/src/report/json.rs
+++ b/crates/sentinel-core/src/report/json.rs
@@ -89,6 +89,7 @@ mod tests {
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: String::new(),
+            disclosure_waste: None,
         };
 
         let json = serde_json::to_string_pretty(&report).unwrap();

--- a/crates/sentinel-core/src/report/metrics.rs
+++ b/crates/sentinel-core/src/report/metrics.rs
@@ -1311,6 +1311,7 @@ mod tests {
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: String::new(),
+            disclosure_waste: None,
         }
     }
 

--- a/crates/sentinel-core/src/report/mod.rs
+++ b/crates/sentinel-core/src/report/mod.rs
@@ -95,6 +95,11 @@ pub struct Report {
     /// on reports written by binaries that predate this field.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub binary_version: String,
+    /// Avoidable energy/carbon tiers (operator + canonical threshold), set
+    /// only by the daemon archive path (the periodic aggregator reads them).
+    /// `None` in batch and live outputs. Additive via `serde(default)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disclosure_waste: Option<DisclosureWaste>,
 }
 
 /// A finding paired with the acknowledgment that suppressed it.
@@ -106,6 +111,26 @@ pub struct Report {
 pub struct AcknowledgedFinding {
     pub finding: Finding,
     pub acknowledgment: crate::acknowledgments::Acknowledgment,
+}
+
+/// Avoidable energy/carbon at one N+1 threshold, archived per window.
+/// `avoidable_kwh`/`avoidable_gco2` are the energy/carbon shares of the
+/// avoidable I/O ops. The aggregator sums these and derives ratio/efficiency
+/// into the period-aggregate `periodic::schema::WasteTier` (gCO₂ → kg there).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct AvoidableTier {
+    pub n_plus_one_threshold: u32,
+    pub avoidable_io_ops: usize,
+    pub avoidable_kwh: f64,
+    pub avoidable_gco2: f64,
+}
+
+/// The two avoidable tiers archived with a daemon window: `canonical` at the
+/// binary-pinned threshold (non-manipulable), `operational` at the operator's.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct DisclosureWaste {
+    pub canonical: AvoidableTier,
+    pub operational: AvoidableTier,
 }
 
 /// Analysis metadata.
@@ -121,6 +146,11 @@ pub struct Analysis {
 pub struct GreenSummary {
     pub total_io_ops: usize,
     pub avoidable_io_ops: usize,
+    /// Region-resolved I/O ops (`total_io_ops` minus the unknown bucket): the
+    /// denominator behind `co2.avoidable`. In-process only (`serde(skip)`),
+    /// read by the daemon to rescale avoidable at the canonical threshold.
+    #[serde(skip)]
+    pub accounted_io_ops: usize,
     pub io_waste_ratio: f64,
     /// Classification band for `io_waste_ratio`
     /// (`healthy` / `moderate` / `high` / `critical`).
@@ -276,6 +306,7 @@ impl GreenSummary {
         Self {
             total_io_ops,
             avoidable_io_ops: 0,
+            accounted_io_ops: total_io_ops,
             io_waste_ratio: 0.0,
             io_waste_ratio_band: InterpretationLevel::Healthy,
             top_offenders: vec![],

--- a/crates/sentinel-core/src/report/periodic/aggregator.rs
+++ b/crates/sentinel-core/src/report/periodic/aggregator.rs
@@ -15,7 +15,7 @@ use crate::report::Report;
 use crate::score::carbon::ENERGY_PER_IO_OP_KWH;
 
 use super::errors::AggregationError;
-use super::schema::{Aggregate, Period};
+use super::schema::{Aggregate, Period, WasteTier};
 
 pub const UNATTRIBUTED_SERVICE: &str = "_unattributed";
 
@@ -201,6 +201,16 @@ struct WindowMetrics {
     runtime_attribution: bool,
 }
 
+/// Period-summed avoidable energy/carbon for one N+1 threshold tier.
+/// `threshold` reconciled by `max` across windows. `avoidable_kg` in kg.
+#[derive(Default)]
+struct WasteTierAccumulator {
+    n_plus_one_threshold: u32,
+    avoidable_io_ops: u64,
+    avoidable_kwh: f64,
+    avoidable_kg: f64,
+}
+
 #[derive(Default)]
 struct Builder {
     per_service: BTreeMap<String, ServiceAccumulator>,
@@ -209,9 +219,10 @@ struct Builder {
     first_seen: BTreeMap<(String, String), DateTime<Utc>>,
     last_seen: BTreeMap<(String, String), DateTime<Utc>>,
     total_io_ops: u64,
-    avoidable_io_ops: u64,
     total_carbon_kgco2eq: f64,
-    avoidable_carbon_kgco2eq: f64,
+    /// Avoidable tiers from each window's `Report.disclosure_waste`.
+    canonical_waste: WasteTierAccumulator,
+    operational_waste: WasteTierAccumulator,
     /// Sum of runtime-calibrated `energy_kwh` for windows that carry it.
     runtime_energy_kwh: f64,
     /// Distinct energy model strings collected across all windows. The
@@ -303,6 +314,7 @@ impl Builder {
         };
 
         self.fold_global_counters(&m);
+        self.fold_disclosure_waste(&report, &m);
         self.fold_binary_version(&report.binary_version);
         self.fold_window_energy_model(&report.green_summary.energy_model);
         self.fold_per_service_measured_ratio(&report.green_summary.per_service_measured_ratio);
@@ -368,11 +380,36 @@ impl Builder {
 
     fn fold_global_counters(&mut self, m: &WindowMetrics) {
         self.windows_aggregated += 1;
-        self.total_io_ops += m.total_io;
-        self.avoidable_io_ops += m.avoidable_io;
+        self.total_io_ops = self.total_io_ops.saturating_add(m.total_io);
         self.total_carbon_kgco2eq += m.carbon_kg;
-        self.avoidable_carbon_kgco2eq += m.avoidable_kg;
         self.runtime_energy_kwh += m.energy_kwh;
+    }
+
+    /// Accumulate the canonical and operational avoidable tiers. A legacy
+    /// archive (no `disclosure_waste`) has no canonical figure, so it feeds
+    /// only the operational tier (best-effort from `green_summary`); the
+    /// canonical tier is left untouched rather than contaminated with
+    /// operator-threshold data, so an all-legacy period fails official
+    /// validation honestly instead of presenting legacy data as canonical.
+    fn fold_disclosure_waste(&mut self, report: &Report, m: &WindowMetrics) {
+        if let Some(dw) = &report.disclosure_waste {
+            fold_tier(&mut self.canonical_waste, &dw.canonical);
+            fold_tier(&mut self.operational_waste, &dw.operational);
+        } else {
+            // accounted_io_ops is not serialized, so the legacy energy share
+            // uses total_io as the denominator (clamped). Threshold stays 0.
+            let ratio = if m.total_io == 0 {
+                0.0
+            } else {
+                (m.avoidable_io as f64 / m.total_io as f64).min(1.0)
+            };
+            self.operational_waste.avoidable_io_ops = self
+                .operational_waste
+                .avoidable_io_ops
+                .saturating_add(m.avoidable_io);
+            self.operational_waste.avoidable_kwh += m.energy_kwh * ratio;
+            self.operational_waste.avoidable_kg += m.avoidable_kg;
+        }
     }
 
     fn fold_binary_version(&mut self, bv: &str) {
@@ -597,12 +634,9 @@ impl Builder {
             self.per_service.values().map(|s| s.energy_kwh).sum()
         };
         let total_carbon = self.total_carbon_kgco2eq;
-        let waste_ratio = if self.total_io_ops == 0 {
-            0.0
-        } else {
-            self.avoidable_io_ops as f64 / self.total_io_ops as f64
-        };
-        let efficiency_score = (100.0 - waste_ratio * 100.0).clamp(0.0, 100.0);
+        // Flat avoidable fields alias the canonical (non-manipulable) tier.
+        let canonical_waste = make_waste_tier(&self.canonical_waste, self.total_io_ops);
+        let operational_waste = make_waste_tier(&self.operational_waste, self.total_io_ops);
         let anti_patterns_count: u64 = self
             .per_service
             .values()
@@ -622,10 +656,12 @@ impl Builder {
                 total_requests,
                 total_energy_kwh,
                 total_carbon_kgco2eq: total_carbon,
-                aggregate_efficiency_score: efficiency_score,
-                aggregate_waste_ratio: waste_ratio.clamp(0.0, 1.0),
+                aggregate_efficiency_score: canonical_waste.efficiency_score,
+                aggregate_waste_ratio: canonical_waste.waste_ratio,
                 anti_patterns_detected_count: anti_patterns_count,
-                estimated_optimization_potential_kgco2eq: self.avoidable_carbon_kgco2eq,
+                estimated_optimization_potential_kgco2eq: canonical_waste.carbon_kgco2eq,
+                canonical_waste,
+                operational_waste,
                 period_coverage,
                 binary_versions: self.binary_versions,
                 runtime_windows_count: self.runtime_windows,
@@ -666,6 +702,43 @@ fn service_io_distribution(
         *out.entry(entry.service.clone()).or_insert(0) += entry.io_ops as u64;
     }
     out
+}
+
+/// Fold one window's avoidable tier into the period accumulator, sanitizing
+/// the energy/carbon against tampered archives.
+fn fold_tier(acc: &mut WasteTierAccumulator, tier: &crate::report::AvoidableTier) {
+    // saturating_add: the counts come from untrusted archive JSON; a wrapping
+    // sum would be a silent under-reporting primitive in a release binary.
+    acc.avoidable_io_ops = acc
+        .avoidable_io_ops
+        .saturating_add(tier.avoidable_io_ops as u64);
+    acc.avoidable_kwh += sanitize_f64(tier.avoidable_kwh);
+    acc.avoidable_kg += sanitize_f64(tier.avoidable_gco2) / 1000.0;
+    acc.n_plus_one_threshold = acc.n_plus_one_threshold.max(tier.n_plus_one_threshold);
+}
+
+/// Derive a [`WasteTier`] from a period accumulator. `waste_ratio` and
+/// `efficiency_score` are computed against the period's total I/O ops.
+fn make_waste_tier(acc: &WasteTierAccumulator, total_io_ops: u64) -> WasteTier {
+    // An accumulator that received no data (threshold 0 and no avoidable ops,
+    // i.e. an all-legacy canonical tier) is the all-zero default, not "100%
+    // efficient". Returning the default lets `skip_serializing_if` omit it,
+    // signalling "no data" rather than a misleading perfect score.
+    if acc.n_plus_one_threshold == 0 && acc.avoidable_io_ops == 0 {
+        return WasteTier::default();
+    }
+    let waste_ratio = if total_io_ops == 0 {
+        0.0
+    } else {
+        acc.avoidable_io_ops as f64 / total_io_ops as f64
+    };
+    WasteTier {
+        n_plus_one_threshold: acc.n_plus_one_threshold,
+        energy_kwh: acc.avoidable_kwh,
+        carbon_kgco2eq: acc.avoidable_kg,
+        waste_ratio: waste_ratio.clamp(0.0, 1.0),
+        efficiency_score: (100.0 - waste_ratio * 100.0).clamp(0.0, 100.0),
+    }
 }
 
 /// Strip non-finite and negative values from any `f64` field read out
@@ -909,6 +982,7 @@ mod tests {
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: String::new(),
+            disclosure_waste: None,
         }
     }
 
@@ -930,6 +1004,50 @@ mod tests {
             period_type: crate::report::periodic::schema::PeriodType::CalendarQuarter,
             days_covered: 90,
         }
+    }
+
+    #[test]
+    fn aggregator_surfaces_both_waste_tiers() {
+        let ts = Utc.with_ymd_and_hms(2026, 1, 15, 0, 0, 0).unwrap();
+        // green_summary avoidable (50) differs from the canonical tier (200),
+        // so the assertions prove the disclosure_waste tiers drive the output,
+        // not the operational green_summary.
+        let mut report = make_report(100, 1_000, 50, &[("svc-a", "/api", 1_000)], vec![]);
+        report.disclosure_waste = Some(crate::report::DisclosureWaste {
+            canonical: crate::report::AvoidableTier {
+                n_plus_one_threshold: 2,
+                avoidable_io_ops: 200,
+                avoidable_kwh: 0.5,
+                avoidable_gco2: 300.0,
+            },
+            operational: crate::report::AvoidableTier {
+                n_plus_one_threshold: 5,
+                avoidable_io_ops: 50,
+                avoidable_kwh: 0.1,
+                avoidable_gco2: 80.0,
+            },
+        });
+
+        let (_dir, path) = write_archive(&[(ts, report)]);
+        let agg = aggregate_from_paths(&[path], &q1_2026(), false)
+            .unwrap()
+            .aggregate;
+
+        assert_eq!(agg.canonical_waste.n_plus_one_threshold, 2);
+        assert_eq!(agg.operational_waste.n_plus_one_threshold, 5);
+        assert!((agg.canonical_waste.carbon_kgco2eq - 0.3).abs() < 1e-9);
+        assert!((agg.operational_waste.carbon_kgco2eq - 0.08).abs() < 1e-9);
+        assert!((agg.canonical_waste.energy_kwh - 0.5).abs() < 1e-9);
+        assert!((agg.operational_waste.energy_kwh - 0.1).abs() < 1e-9);
+        assert!((agg.canonical_waste.waste_ratio - 0.2).abs() < 1e-9);
+        assert!((agg.operational_waste.waste_ratio - 0.05).abs() < 1e-9);
+        // Flat fields alias the canonical tier.
+        assert!(
+            (agg.estimated_optimization_potential_kgco2eq - agg.canonical_waste.carbon_kgco2eq)
+                .abs()
+                < 1e-12
+        );
+        assert!((agg.aggregate_waste_ratio - agg.canonical_waste.waste_ratio).abs() < 1e-12);
     }
 
     #[test]
@@ -963,8 +1081,14 @@ mod tests {
         assert_eq!(out.windows_aggregated, 3);
         assert_eq!(out.aggregate.total_requests, 100 + 200 + 150);
         assert!(out.aggregate.total_energy_kwh > 0.0);
-        assert!(out.aggregate.aggregate_waste_ratio > 0.0);
-        assert!(out.aggregate.aggregate_efficiency_score < 100.0);
+        // These windows are legacy (no disclosure_waste), so the avoidable
+        // figures land only in the operational tier; the canonical tier stays
+        // the all-zero default (omitted on the wire, not "100% efficient")
+        // rather than being fed legacy data, and the flat aliases stay zero.
+        assert!(out.aggregate.operational_waste.waste_ratio > 0.0);
+        assert!(out.aggregate.operational_waste.efficiency_score < 100.0);
+        assert_eq!(out.aggregate.canonical_waste, WasteTier::default());
+        assert!(out.aggregate.aggregate_waste_ratio.abs() < 1e-12);
         assert_eq!(out.aggregate.anti_patterns_detected_count, 3);
 
         let svc_a = out.per_service.get("svc-a").expect("svc-a missing");

--- a/crates/sentinel-core/src/report/periodic/hasher.rs
+++ b/crates/sentinel-core/src/report/periodic/hasher.rs
@@ -229,6 +229,29 @@ mod tests {
     }
 
     #[test]
+    fn content_hash_survives_json_roundtrip() {
+        // verify-hash reparses the report from a file before recomputing the
+        // hash, so the hash must be stable across serialize -> parse. With
+        // messy floats (long mantissas, the kind disclose produces) the
+        // default serde_json parser can shift a value by 1 ULP and break the
+        // hash of an untampered report. The `float_roundtrip` feature makes
+        // parsing exact. This guards against that feature being dropped.
+        let mut r = sample_report();
+        r.aggregate.total_energy_kwh = 2.0 / 3.0;
+        r.aggregate.total_carbon_kgco2eq = 1.0 / 7.0;
+        r.aggregate.canonical_waste.energy_kwh = 100.0 * 5.0 / 6.0 * 1e-7;
+        r.aggregate.canonical_waste.carbon_kgco2eq = 10.0 * 5.0 / 6.0 / 1000.0;
+        r.aggregate.operational_waste.energy_kwh = 1.0 / 11.0;
+
+        let before = compute_content_hash(&r).unwrap();
+        let json = serde_json::to_string(&r).unwrap();
+        let reparsed: PeriodicReport = serde_json::from_str(&json).unwrap();
+        let after = compute_content_hash(&reparsed).unwrap();
+
+        assert_eq!(before, after, "content_hash must survive a JSON round-trip");
+    }
+
+    #[test]
     fn hash_changes_on_aggregate_mutation() {
         let r = sample_report();
         let baseline = compute_content_hash(&r).unwrap();

--- a/crates/sentinel-core/src/report/periodic/hasher.rs
+++ b/crates/sentinel-core/src/report/periodic/hasher.rs
@@ -349,6 +349,14 @@ mod tests {
         );
 
         let mut m = r.clone();
+        m.aggregate.canonical_waste.n_plus_one_threshold += 1;
+        assert_ne!(
+            compute_content_hash(&m).unwrap(),
+            baseline,
+            "aggregate.canonical_waste.n_plus_one_threshold"
+        );
+
+        let mut m = r.clone();
         m.methodology.sci_specification = format!("{}-v2", m.methodology.sci_specification);
         assert_ne!(
             compute_content_hash(&m).unwrap(),

--- a/crates/sentinel-core/src/report/periodic/mod.rs
+++ b/crates/sentinel-core/src/report/periodic/mod.rs
@@ -1,4 +1,4 @@
-//! Periodic disclosure report (v1.0).
+//! Periodic disclosure report (v1.1).
 //!
 //! A separate JSON document type, distinct from the per-batch [`Report`]
 //! tree, aggregated over a calendar period (default quarter). Designed

--- a/crates/sentinel-core/src/report/periodic/schema.rs
+++ b/crates/sentinel-core/src/report/periodic/schema.rs
@@ -1,13 +1,20 @@
-//! Wire schema (v1.0) for the periodic disclosure report.
+//! Wire schema (v1.1) for the periodic disclosure report.
 //! See `docs/design/08-PERIODIC-DISCLOSURE.md` for ordering and
 //! determinism invariants that any change here must preserve.
+//!
+//! v1.1 adds the `canonical_waste` / `operational_waste` tiers to
+//! `Aggregate`: avoidable energy and carbon at the binary-pinned canonical
+//! N+1 threshold and at the operator's configured threshold, side by side.
+//! The pre-existing flat avoidable fields are retained as aliases of the
+//! canonical tier. Additive via `serde(default)`, so v1.0 readers and
+//! reports remain compatible.
 
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use uuid::Uuid;
 
-pub const SCHEMA_VERSION: &str = "perf-sentinel-report/v1.0";
+pub const SCHEMA_VERSION: &str = "perf-sentinel-report/v1.1";
 
 /// Patterns that an `intent = "official"` disclosure must keep enabled.
 /// Aligned with `FindingType::is_avoidable_io()`: the four patterns whose
@@ -212,15 +219,57 @@ pub struct CalibrationInputs {
     pub calibration_applied: bool,
 }
 
+/// Avoidable energy and carbon for one N+1 threshold, summed over the period.
+///
+/// `n_plus_one_threshold` is the threshold that produced these figures: the
+/// binary-pinned [`crate::detect::DISCLOSURE_N_PLUS_ONE_THRESHOLD`] for the
+/// canonical tier, the operator's configured value for the operational tier.
+/// `waste_ratio` is `avoidable_io_ops / total_io_ops` over the period and
+/// `efficiency_score` is `100 - waste_ratio * 100`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct WasteTier {
+    pub n_plus_one_threshold: u32,
+    pub energy_kwh: f64,
+    pub carbon_kgco2eq: f64,
+    pub waste_ratio: f64,
+    pub efficiency_score: f64,
+}
+
+impl WasteTier {
+    /// True when the tier is the all-zero default (a v1.0 / pre-canonical
+    /// report). Drives `skip_serializing_if` so absent tiers stay absent on
+    /// the wire and the `content_hash` is stable across schema versions.
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Aggregate {
     pub total_requests: u64,
     pub total_energy_kwh: f64,
     pub total_carbon_kgco2eq: f64,
+    /// Period efficiency. Since v1.1 this aliases `canonical_waste.efficiency_score`
+    /// (the non-manipulable tier); pre-v1.1 it carried the operator-threshold value.
     pub aggregate_efficiency_score: f64,
+    /// Period waste ratio. Since v1.1 this aliases `canonical_waste.waste_ratio`.
     pub aggregate_waste_ratio: f64,
     pub anti_patterns_detected_count: u64,
+    /// Avoidable carbon. Since v1.1 this aliases `canonical_waste.carbon_kgco2eq`.
     pub estimated_optimization_potential_kgco2eq: f64,
+    /// Avoidable energy/carbon at the binary-pinned canonical N+1 threshold.
+    /// Non-manipulable by operator config: this is the headline disclosure
+    /// figure. `Default` (all zeros, threshold 0) for v1.0 reports.
+    /// `skip_serializing_if` omits the default so a v1.0 report re-hashed on
+    /// a v1.1 binary keeps the same `content_hash`.
+    #[serde(default, skip_serializing_if = "WasteTier::is_default")]
+    pub canonical_waste: WasteTier,
+    /// Avoidable energy/carbon at the operator's configured N+1 threshold,
+    /// recorded with that threshold so the gap to `canonical_waste` is
+    /// visible. `Default` for v1.0 reports.
+    #[serde(default, skip_serializing_if = "WasteTier::is_default")]
+    pub operational_waste: WasteTier,
     /// Fraction of the period's scoring windows that used runtime-calibrated
     /// energy attribution. `1.0` when every window provided runtime energy,
     /// `0.0` when every window fell back to the proxy. Defined as
@@ -465,6 +514,20 @@ mod tests {
             aggregate_waste_ratio: 0.18,
             anti_patterns_detected_count: 47,
             estimated_optimization_potential_kgco2eq: 0.25,
+            canonical_waste: WasteTier {
+                n_plus_one_threshold: 2,
+                energy_kwh: 2.1,
+                carbon_kgco2eq: 0.25,
+                waste_ratio: 0.18,
+                efficiency_score: 82.0,
+            },
+            operational_waste: WasteTier {
+                n_plus_one_threshold: 5,
+                energy_kwh: 0.9,
+                carbon_kgco2eq: 0.12,
+                waste_ratio: 0.08,
+                efficiency_score: 92.0,
+            },
             period_coverage: 1.0,
             binary_versions: BTreeSet::new(),
             runtime_windows_count: 0,
@@ -561,6 +624,25 @@ mod tests {
         assert_eq!(json, json2);
         assert_eq!(back.schema_version, SCHEMA_VERSION);
         assert!(back.applications.is_empty());
+    }
+
+    #[test]
+    fn default_waste_tiers_omitted_from_serialization() {
+        // A v1.0 / pre-canonical report has all-zero tiers; they must be
+        // omitted so re-hashing it on a v1.1 binary keeps content_hash stable.
+        let mut agg = sample_aggregate();
+        assert!(
+            serde_json::to_value(&agg)
+                .unwrap()
+                .get("canonical_waste")
+                .is_some()
+        );
+
+        agg.canonical_waste = WasteTier::default();
+        agg.operational_waste = WasteTier::default();
+        let json = serde_json::to_value(&agg).unwrap();
+        assert!(json.get("canonical_waste").is_none());
+        assert!(json.get("operational_waste").is_none());
     }
 
     #[test]

--- a/crates/sentinel-core/src/report/periodic/test_fixtures.rs
+++ b/crates/sentinel-core/src/report/periodic/test_fixtures.rs
@@ -138,7 +138,7 @@ pub(super) fn sample_report(
     confidentiality: Confidentiality,
     applications: Vec<Application>,
 ) -> PeriodicReport {
-    use super::schema::Aggregate;
+    use super::schema::{Aggregate, WasteTier};
     PeriodicReport {
         schema_version: SCHEMA_VERSION.to_string(),
         report_metadata: sample_metadata(intent, confidentiality),
@@ -154,6 +154,20 @@ pub(super) fn sample_report(
             aggregate_waste_ratio: 0.1,
             anti_patterns_detected_count: 3,
             estimated_optimization_potential_kgco2eq: 0.01,
+            canonical_waste: WasteTier {
+                n_plus_one_threshold: 2,
+                energy_kwh: 0.04,
+                carbon_kgco2eq: 0.01,
+                waste_ratio: 0.1,
+                efficiency_score: 90.0,
+            },
+            operational_waste: WasteTier {
+                n_plus_one_threshold: 5,
+                energy_kwh: 0.02,
+                carbon_kgco2eq: 0.005,
+                waste_ratio: 0.05,
+                efficiency_score: 95.0,
+            },
             period_coverage: 1.0,
             binary_versions: BTreeSet::new(),
             runtime_windows_count: 0,

--- a/crates/sentinel-core/src/report/periodic/validator.rs
+++ b/crates/sentinel-core/src/report/periodic/validator.rs
@@ -3,11 +3,13 @@
 //! See `docs/design/08-PERIODIC-DISCLOSURE.md` for the rule list and
 //! the rationale for collecting every error in one pass.
 
+use crate::detect::DISCLOSURE_N_PLUS_ONE_THRESHOLD;
+
 use super::errors::ValidationError;
 use super::hasher::compute_content_hash;
 use super::schema::{
     Aggregate, Application, ApplicationG1, ApplicationG2, Confidentiality, Conformance,
-    Methodology, Organisation, Period, PeriodicReport, ReportIntent, ScopeManifest,
+    Methodology, Organisation, Period, PeriodicReport, ReportIntent, ScopeManifest, WasteTier,
 };
 
 /// All pattern names known to perf-sentinel, kept in sync with
@@ -356,6 +358,63 @@ fn validate_aggregate(agg: &Aggregate, errors: &mut Vec<ValidationError>) {
                  excludes non-calibrated windows, or set intent=internal.",
                 agg.period_coverage * 100.0,
                 MIN_PERIOD_COVERAGE_FOR_OFFICIAL * 100.0,
+            ),
+        });
+    }
+    validate_waste_tiers(agg, errors);
+}
+
+/// Validate the canonical/operational avoidable tiers. The canonical tier
+/// must carry the binary-pinned threshold, else the figure was not computed
+/// at the non-manipulable threshold. The operational threshold is the
+/// operator's recorded choice and is deliberately not range-checked: a loose
+/// operator threshold is exactly what this tier exists to surface.
+fn validate_waste_tiers(agg: &Aggregate, errors: &mut Vec<ValidationError>) {
+    validate_waste_tier("canonical_waste", &agg.canonical_waste, errors);
+    validate_waste_tier("operational_waste", &agg.operational_waste, errors);
+
+    let canonical = agg.canonical_waste.n_plus_one_threshold;
+    if canonical != DISCLOSURE_N_PLUS_ONE_THRESHOLD {
+        let reason = if canonical == 0 {
+            "n_plus_one_threshold is 0: the period contains only archives that predate \
+             canonical disclosure. Regenerate over post-upgrade windows or use intent=internal."
+                .to_string()
+        } else {
+            format!(
+                "n_plus_one_threshold must equal the canonical {DISCLOSURE_N_PLUS_ONE_THRESHOLD}, got {canonical}"
+            )
+        };
+        errors.push(ValidationError::Aggregate {
+            field: "canonical_waste",
+            reason,
+        });
+    }
+}
+
+fn validate_waste_tier(name: &'static str, tier: &WasteTier, errors: &mut Vec<ValidationError>) {
+    for (sub, value) in [
+        ("energy_kwh", tier.energy_kwh),
+        ("carbon_kgco2eq", tier.carbon_kgco2eq),
+    ] {
+        if !value.is_finite() || value < 0.0 {
+            errors.push(ValidationError::Aggregate {
+                field: name,
+                reason: format!("{sub} must be a finite number >= 0, got {value}"),
+            });
+        }
+    }
+    if !tier.waste_ratio.is_finite() || !(0.0..=1.0).contains(&tier.waste_ratio) {
+        errors.push(ValidationError::Aggregate {
+            field: name,
+            reason: format!("waste_ratio must be in [0, 1], got {}", tier.waste_ratio),
+        });
+    }
+    if !tier.efficiency_score.is_finite() || !(0.0..=100.0).contains(&tier.efficiency_score) {
+        errors.push(ValidationError::Aggregate {
+            field: name,
+            reason: format!(
+                "efficiency_score must be in [0, 100], got {}",
+                tier.efficiency_score
             ),
         });
     }
@@ -721,6 +780,29 @@ mod tests {
                     if *field == "aggregate_waste_ratio")),
             "got {errors:?}"
         );
+    }
+
+    #[test]
+    fn canonical_waste_threshold_mismatch_rejected() {
+        let mut r = good_report(ReportIntent::Official, Confidentiality::Internal);
+        r.aggregate.canonical_waste.n_plus_one_threshold = DISCLOSURE_N_PLUS_ONE_THRESHOLD + 1;
+        let errors = validate_official(&r).unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::Aggregate { field, reason }
+                    if *field == "canonical_waste" && reason.contains("canonical"))),
+            "got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn high_operational_threshold_accepted() {
+        // The operator's threshold is recorded, not range-checked: a loose
+        // threshold is exactly what the operational tier exists to surface.
+        let mut r = good_report(ReportIntent::Official, Confidentiality::Internal);
+        r.aggregate.operational_waste.n_plus_one_threshold = 5_000;
+        validate_official(&r).expect("a high operator threshold must not fail validation");
     }
 
     #[test]

--- a/crates/sentinel-core/src/report/sarif.rs
+++ b/crates/sentinel-core/src/report/sarif.rs
@@ -583,6 +583,7 @@ mod tests {
             warning_details: vec![],
             acknowledged_findings: vec![],
             binary_version: String::new(),
+            disclosure_waste: None,
         }
     }
 

--- a/crates/sentinel-core/src/score/canonical.rs
+++ b/crates/sentinel-core/src/score/canonical.rs
@@ -4,7 +4,7 @@
 //! findings, so raising it shrinks the avoidable energy/carbon a disclosure
 //! would report. To keep the public figure non-manipulable, the daemon
 //! archives the avoidable at a fixed canonical threshold
-//! ([`crate::detect::DISCLOSURE_N_PLUS_ONE_THRESHOLD`]) alongside the
+//! ([`DISCLOSURE_N_PLUS_ONE_THRESHOLD`]) alongside the
 //! operator-threshold one. Daemon-only (the `disclose` subcommand reads
 //! pre-computed tiers); the anti-gaming invariant tests run under the
 //! `daemon` feature (`cargo test -p perf-sentinel-core --features daemon`).

--- a/crates/sentinel-core/src/score/canonical.rs
+++ b/crates/sentinel-core/src/score/canonical.rs
@@ -1,0 +1,140 @@
+//! Canonical-threshold avoidable computation for periodic disclosure.
+//!
+//! The operator's `n_plus_one_threshold` decides which N+1 patterns become
+//! findings, so raising it shrinks the avoidable energy/carbon a disclosure
+//! would report. To keep the public figure non-manipulable, the daemon
+//! archives the avoidable at a fixed canonical threshold
+//! ([`crate::detect::DISCLOSURE_N_PLUS_ONE_THRESHOLD`]) alongside the
+//! operator-threshold one. Daemon-only (the `disclose` subcommand reads
+//! pre-computed tiers); the anti-gaming invariant tests run under the
+//! `daemon` feature (`cargo test -p perf-sentinel-core --features daemon`).
+
+use crate::correlate::Trace;
+use crate::detect::{DISCLOSURE_N_PLUS_ONE_THRESHOLD, DetectConfig, n_plus_one, redundant};
+use crate::report::{AvoidableTier, DisclosureWaste, GreenSummary};
+
+use super::dedup_avoidable_io_ops;
+use super::region_breakdown::avoidable_share;
+
+/// Re-run N+1 at [`DISCLOSURE_N_PLUS_ONE_THRESHOLD`] (then redundant against
+/// that set) over every trace, and dedup the avoidable I/O ops. Only the N+1
+/// threshold is overridden; window and sanitizer mode stay as configured.
+#[must_use]
+pub(crate) fn compute_canonical_avoidable(traces: &[Trace], detect_config: &DetectConfig) -> usize {
+    let mut findings = Vec::new();
+    for trace in traces {
+        let mut n1 = n_plus_one::detect_n_plus_one(
+            trace,
+            DISCLOSURE_N_PLUS_ONE_THRESHOLD,
+            detect_config.window_ms,
+            detect_config.sanitizer_aware_classification,
+        );
+        let mut redundant = redundant::detect_redundant(trace, &n1);
+        findings.append(&mut n1);
+        findings.append(&mut redundant);
+    }
+    dedup_avoidable_io_ops(&findings)
+}
+
+/// Build both avoidable tiers from the scored operational [`GreenSummary`]
+/// plus a canonical detection pass. Operational carbon reuses the summary's
+/// `co2.avoidable`; canonical carbon is rescaled from `operational_gco2` via
+/// [`avoidable_share`] (same denominator). No second carbon pass.
+#[must_use]
+pub(crate) fn compute_disclosure_waste(
+    traces: &[Trace],
+    operational: &GreenSummary,
+    detect_config: &DetectConfig,
+) -> DisclosureWaste {
+    let accounted = operational.accounted_io_ops;
+    let energy_kwh = operational.energy_kwh;
+    let operational_gco2 = operational.co2.as_ref().map_or(0.0, |r| r.operational_gco2);
+    let operational_avoidable_gco2 = operational.co2.as_ref().map_or(0.0, |r| r.avoidable.mid);
+
+    let canonical_io = compute_canonical_avoidable(traces, detect_config);
+
+    DisclosureWaste {
+        canonical: AvoidableTier {
+            n_plus_one_threshold: DISCLOSURE_N_PLUS_ONE_THRESHOLD,
+            avoidable_io_ops: canonical_io,
+            avoidable_kwh: avoidable_share(energy_kwh, canonical_io, accounted),
+            avoidable_gco2: avoidable_share(operational_gco2, canonical_io, accounted),
+        },
+        operational: AvoidableTier {
+            n_plus_one_threshold: detect_config.n_plus_one_threshold,
+            avoidable_io_ops: operational.avoidable_io_ops,
+            avoidable_kwh: avoidable_share(energy_kwh, operational.avoidable_io_ops, accounted),
+            avoidable_gco2: operational_avoidable_gco2,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::score::carbon::{CarbonEstimate, CarbonReport};
+    use crate::test_helpers::{make_n_plus_one_events, make_trace};
+
+    fn detect_config(n_plus_one_threshold: u32) -> DetectConfig {
+        let mut cfg = DetectConfig::from(&Config::default());
+        cfg.n_plus_one_threshold = n_plus_one_threshold;
+        cfg
+    }
+
+    /// Anti-gaming invariant: the canonical avoidable count is identical
+    /// whether the operator's threshold is sensitive (2) or so high it finds
+    /// nothing (50). The 6-occurrence fixture yields `6 - 1 = 5` avoidable
+    /// ops at the canonical threshold regardless.
+    #[test]
+    fn canonical_avoidable_independent_of_operational_threshold() {
+        let traces = vec![make_trace(make_n_plus_one_events())];
+
+        let low = compute_canonical_avoidable(&traces, &detect_config(2));
+        let high = compute_canonical_avoidable(&traces, &detect_config(50));
+
+        assert_eq!(
+            low, high,
+            "canonical count must not depend on operator config"
+        );
+        assert_eq!(low, 5);
+    }
+
+    /// With the operator threshold at 50 the operational tier sees zero
+    /// avoidable, while the canonical tier still reports the waste with its
+    /// energy and carbon shares.
+    #[test]
+    fn disclosure_waste_keeps_canonical_when_operational_hidden() {
+        let traces = vec![make_trace(make_n_plus_one_events())];
+        let operational = GreenSummary {
+            total_io_ops: 6,
+            avoidable_io_ops: 0,
+            accounted_io_ops: 6,
+            energy_kwh: 2.0,
+            co2: Some(CarbonReport {
+                total: CarbonEstimate::sci_numerator(12.0),
+                avoidable: CarbonEstimate::operational_ratio(0.0),
+                operational_gco2: 12.0,
+                embodied_gco2: 0.0,
+                transport_gco2: None,
+            }),
+            ..GreenSummary::disabled(0)
+        };
+
+        let waste = compute_disclosure_waste(&traces, &operational, &detect_config(50));
+
+        // Operator tier is empty (threshold 50 finds nothing).
+        assert_eq!(waste.operational.n_plus_one_threshold, 50);
+        assert_eq!(waste.operational.avoidable_io_ops, 0);
+        assert!(waste.operational.avoidable_gco2.abs() < 1e-12);
+        assert!(waste.operational.avoidable_kwh.abs() < 1e-12);
+
+        // Canonical tier still reports the waste: 5 ops out of 6 accounted.
+        assert_eq!(waste.canonical.n_plus_one_threshold, 2);
+        assert_eq!(waste.canonical.avoidable_io_ops, 5);
+        // 12.0 gCO2 * (5 / 6)
+        assert!((waste.canonical.avoidable_gco2 - 10.0).abs() < 1e-9);
+        // 2.0 kWh * (5 / 6)
+        assert!((waste.canonical.avoidable_kwh - (2.0 * 5.0 / 6.0)).abs() < 1e-9);
+    }
+}

--- a/crates/sentinel-core/src/score/carbon_compute.rs
+++ b/crates/sentinel-core/src/score/carbon_compute.rs
@@ -120,6 +120,11 @@ pub(super) struct CarbonComputeOutputs {
     pub multi_region_active: bool,
     pub per_service: BTreeMap<String, ServiceCarbonAccumulator>,
     pub window_model: &'static str,
+    /// I/O ops whose region was resolved (`total_io_ops` minus the
+    /// unknown-region bucket). Denominator of the avoidable-CO₂ ratio,
+    /// surfaced so the disclosure path can rescale avoidable at a
+    /// canonical threshold without a second carbon pass.
+    pub accounted_io_ops: usize,
 }
 
 /// Compute carbon report, per-region breakdown, and multi-region flag.
@@ -149,6 +154,7 @@ pub(super) fn compute_carbon_report(
             multi_region_active: state.multi_region_active,
             per_service: BTreeMap::new(),
             window_model: "",
+            accounted_io_ops: 0,
         };
     }
 
@@ -178,6 +184,7 @@ pub(super) fn compute_carbon_report(
         multi_region_active: state.multi_region_active,
         per_service: state.per_service,
         window_model: model,
+        accounted_io_ops: total_io_ops.saturating_sub(state.unknown_ops),
     }
 }
 

--- a/crates/sentinel-core/src/score/mod.rs
+++ b/crates/sentinel-core/src/score/mod.rs
@@ -20,6 +20,10 @@ pub(crate) mod ops_snapshot_diff;
 pub mod redfish;
 pub mod scaphandre;
 
+// Daemon-only: the canonical avoidable pass runs at archive time. The
+// `disclose` subcommand reads pre-computed tiers, it never recomputes them.
+#[cfg(feature = "daemon")]
+pub(crate) mod canonical;
 mod carbon_compute;
 mod region_breakdown;
 
@@ -161,6 +165,7 @@ pub fn score_green(
             multi_region_active: false,
             per_service: std::collections::BTreeMap::new(),
             window_model: "",
+            accounted_io_ops: total_io_ops,
         },
     };
 
@@ -185,6 +190,7 @@ pub fn score_green(
     let green_summary = GreenSummary {
         total_io_ops,
         avoidable_io_ops,
+        accounted_io_ops: carbon_outputs.accounted_io_ops,
         io_waste_ratio,
         io_waste_ratio_band: crate::report::interpret::InterpretationLevel::for_waste_ratio(
             io_waste_ratio,
@@ -212,7 +218,7 @@ pub fn score_green(
 /// Dedup avoidable I/O ops by (`trace_id`, template, `source_endpoint`),
 /// taking max. Slow findings are not avoidable I/O, they are necessary
 /// operations that happen to be slow.
-fn dedup_avoidable_io_ops(findings: &[Finding]) -> usize {
+pub(crate) fn dedup_avoidable_io_ops(findings: &[Finding]) -> usize {
     let capacity = findings
         .iter()
         .filter(|f| f.finding_type.is_avoidable_io())

--- a/crates/sentinel-core/src/score/region_breakdown.rs
+++ b/crates/sentinel-core/src/score/region_breakdown.rs
@@ -290,6 +290,29 @@ fn select_proxy_co2_model_tag(
     }
 }
 
+/// Region-blind avoidable share: `window_total` (operational CO₂ or energy)
+/// scaled by the fraction of accounted I/O ops that are avoidable, clamped
+/// to 1.0.
+///
+/// Units-neutral and shared by [`finalize_carbon_report`] and the
+/// canonical-disclosure rescale (`score::canonical`) so the operational and
+/// canonical avoidable figures cannot drift on the formula. The clamp guards
+/// the pathological case where avoidable ops from unknown-region spans exceed
+/// the accounted denominator.
+#[must_use]
+pub(super) fn avoidable_share(
+    window_total: f64,
+    avoidable_io_ops: usize,
+    accounted_io_ops: usize,
+) -> f64 {
+    if accounted_io_ops > 0 {
+        let ratio = (avoidable_io_ops as f64 / accounted_io_ops as f64).min(1.0);
+        window_total * ratio
+    } else {
+        0.0
+    }
+}
+
 /// Final assembly of the [`CarbonReport`] struct: SCI v1.0 numerator
 /// (E × I + M + T), avoidable CO₂ via region-blind ratio, and the
 /// methodology tag that shifts when network transport is included.
@@ -319,15 +342,7 @@ pub(super) fn finalize_carbon_report(
     // Embodied is NOT included in avoidable: hardware emissions are fixed
     // regardless of whether the application does N+1 queries.
     let accounted_io_ops = total_io_ops.saturating_sub(unknown_ops);
-    let avoidable_mid = if accounted_io_ops > 0 {
-        // Clamp ratio to 1.0: in pathological cases (avoidable ops from
-        // unknown-region spans exceeding accounted ops) the ratio can
-        // exceed 1.0, which would produce avoidable > operational.
-        let ratio = (avoidable_io_ops as f64 / accounted_io_ops as f64).min(1.0);
-        operational_gco2 * ratio
-    } else {
-        0.0
-    };
+    let avoidable_mid = avoidable_share(operational_gco2, avoidable_io_ops, accounted_io_ops);
 
     let transport_gco2 = if total_transport_gco2 > 0.0 {
         Some(total_transport_gco2)

--- a/crates/sentinel-core/src/test_helpers.rs
+++ b/crates/sentinel-core/src/test_helpers.rs
@@ -32,6 +32,7 @@ pub fn empty_report() -> Report {
         warning_details: vec![],
         acknowledged_findings: vec![],
         binary_version: env!("CARGO_PKG_VERSION").to_string(),
+        disclosure_waste: None,
     }
 }
 

--- a/crates/sentinel-core/tests/periodic_examples.rs
+++ b/crates/sentinel-core/tests/periodic_examples.rs
@@ -28,7 +28,7 @@ fn load_example(rel: &str) -> PeriodicReport {
 #[test]
 fn example_internal_g1_parses_and_validates() {
     let r = load_example("docs/schemas/examples/example-internal-G1.json");
-    assert_eq!(r.schema_version, "perf-sentinel-report/v1.0");
+    assert_eq!(r.schema_version, "perf-sentinel-report/v1.1");
     assert_matches!(r.report_metadata.intent, ReportIntent::Internal);
     assert_matches!(
         r.report_metadata.confidentiality_level,
@@ -50,7 +50,7 @@ fn example_internal_g1_parses_and_validates() {
 #[test]
 fn example_official_public_g2_parses_and_validates() {
     let r = load_example("docs/schemas/examples/example-official-public-G2.json");
-    assert_eq!(r.schema_version, "perf-sentinel-report/v1.0");
+    assert_eq!(r.schema_version, "perf-sentinel-report/v1.1");
     assert_matches!(r.report_metadata.intent, ReportIntent::Official);
     assert_matches!(
         r.report_metadata.confidentiality_level,

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -434,7 +434,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.8.1"
+      PERF_SENTINEL_VERSION: "0.8.2"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/FR/CI-FR.md
+++ b/docs/FR/CI-FR.md
@@ -486,7 +486,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.8.1"
+      PERF_SENTINEL_VERSION: "0.8.2"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/FR/REPORTING-FR.md
+++ b/docs/FR/REPORTING-FR.md
@@ -60,6 +60,15 @@ Seuls `--input` et `--org-config` restent requis. La période, l'intent et la co
 
 La prévisualisation nécessite un terminal interactif. Rediriger sa sortie (pas de TTY) se termine sur une erreur claire au lieu d'afficher quoi que ce soit.
 
+## Gaspillage évitable : canonique versus opérationnel (1.1+)
+
+Un rapport porte l'énergie et le carbone opérationnels totaux de la charge (dérivés des spans, non réglables) plus deux tiers de gaspillage évitable :
+
+- **Canonique** (`aggregate.canonical_waste`). Calculé à un seuil N+1 fixe épinglé dans le binaire (`2`), indépendamment du `[detection] n_plus_one_threshold` de l'opérateur. C'est le chiffre non manipulable : relever votre propre seuil ne peut pas le réduire. C'est le chiffre évitable de référence, et au seuil opérateur par défaut de `5` il est typiquement plus grand que ce que le tableau de bord de l'opérateur affiche.
+- **Opérationnel** (`aggregate.operational_waste`). Calculé au seuil configuré par l'opérateur et enregistré avec ce seuil.
+
+Publier les deux garde la disclosure honnête : un lecteur compare les deux et voit combien de gaspillage évitable un seuil opérateur relâché masquerait. Pour `intent = official`, le validator refuse un rapport dont le `canonical_waste.n_plus_one_threshold` n'est pas la valeur canonique du binaire.
+
 ![prévisualisation disclose, vue mois : en-tête des réglages, résumé agrégé, et la commande équivalente en pied de page](https://raw.githubusercontent.com/robintra/perf-sentinel/main/docs/img/disclose/preview.png)
 
 ![prévisualisation disclose, vue trimestre : le stepper `g` élargit la période au trimestre entier](https://raw.githubusercontent.com/robintra/perf-sentinel/main/docs/img/disclose/quarter.png)

--- a/docs/FR/SCHEMA-FR.md
+++ b/docs/FR/SCHEMA-FR.md
@@ -1,12 +1,14 @@
-# Référence schéma : perf-sentinel-report v1.0
+# Référence schéma : perf-sentinel-report v1.1
 
 Ce document décrit la forme JSON d'un rapport de transparence périodique en prose. Le JSON Schema lisible par machine se trouve dans `docs/schemas/perf-sentinel-report-v1.json` (draft 2020-12). Deux exemples remplis sont sous `docs/schemas/examples/`.
+
+La v1.1 ajoute les tiers `canonical_waste` et `operational_waste` à `aggregate`. Le schéma accepte à la fois `perf-sentinel-report/v1.0` et `v1.1`, et les nouveaux champs prennent une valeur par défaut quand ils sont absents, donc les lecteurs et rapports v1.0 restent valides.
 
 ## Clés racine
 
 | clé               | type           | requise | notes                                                                             |
 |-------------------|----------------|---------|-----------------------------------------------------------------------------------|
-| `schema_version`  | string (const) | oui     | `"perf-sentinel-report/v1.0"`                                                     |
+| `schema_version`  | string (enum)  | oui     | `"perf-sentinel-report/v1.1"` (accepte aussi `"…/v1.0"`)                          |
 | `report_metadata` | object         | oui     | voir [Métadonnées de rapport](#métadonnées-de-rapport)                            |
 | `organisation`    | object         | oui     | voir [Organisation](#organisation)                                                |
 | `period`          | object         | oui     | voir [Période](#période)                                                          |
@@ -50,6 +52,15 @@ Le domaine de publication (par exemple `transparency.example.fr`) est traité co
 > **Voir aussi.** L'[introduction énergie et SCI](METHODOLOGY-FR.md#introduction-énergie-et-sci-v10) dans la doc méthodologie définit les termes SCI v1.0 (E, I, M), `efficiency_score`, `io_waste_ratio`, Scaphandre, SPECpower et le vocabulaire associé utilisé par tous les champs ci-dessous.
 
 Sommes sur toute la période et tout le tableau `applications`. `total_requests`, `total_energy_kwh`, `total_carbon_kgco2eq` et `estimated_optimization_potential_kgco2eq` sont des nombres finis non négatifs. `aggregate_waste_ratio` est dans `[0, 1]`. `aggregate_efficiency_score` est dans `[0, 100]` et vaut `clamp(100 - 100 * io_waste_ratio, 0, 100)`. `anti_patterns_detected_count` est la somme de toutes les occurrences par service, y compris les patterns non évitables.
+
+### Tiers de gaspillage (1.1+)
+
+Le rapport porte le gaspillage évitable, énergie et carbone, à deux seuils de détection N+1, côte à côte, pour rendre l'écart auditable :
+
+- `canonical_waste` est calculé à un seuil N+1 fixe épinglé dans le binaire (`2`), pas la config de l'opérateur. C'est le chiffre non manipulable : un opérateur ne peut pas le réduire en relâchant son propre seuil. C'est le chiffre évitable de référence, et depuis la v1.1 les champs plats `estimated_optimization_potential_kgco2eq`, `aggregate_waste_ratio` et `aggregate_efficiency_score` sont des alias de ce tier (ils portaient la valeur opérationnelle en v1.0).
+- `operational_waste` est calculé au seuil N+1 configuré par l'opérateur et enregistre ce seuil dans `n_plus_one_threshold`. Le comparer à `canonical_waste` montre combien de gaspillage évitable le seuil de l'opérateur masque.
+
+Chaque tier porte `n_plus_one_threshold` (entier), `energy_kwh` et `carbon_kgco2eq` (non négatifs), `waste_ratio` (`[0, 1]`) et `efficiency_score` (`[0, 100]`). Pour `intent = "official"`, le validator exige que `canonical_waste.n_plus_one_threshold` égale le seuil canonique du binaire. Le seuil opérationnel est le choix enregistré de l'opérateur et n'est délibérément pas borné, puisqu'un seuil relâché est précisément ce que ce tier sert à exposer. L'énergie et le carbone totaux (`total_energy_kwh`, `total_carbon_kgco2eq`) sont dérivés des spans et indépendants des deux seuils.
 
 ### Signaux de qualité (0.7.0+)
 

--- a/docs/FR/design/08-PERIODIC-DISCLOSURE-FR.md
+++ b/docs/FR/design/08-PERIODIC-DISCLOSURE-FR.md
@@ -97,6 +97,16 @@ L'aggregator a besoin de `green_summary` (pour énergie/carbone) et de `per_endp
 
 `per_endpoint_io_ops` était auparavant lié à `_` dans `process_traces` (la valeur était déjà calculée par `score_green` mais jetée). La garder pour l'archive est un changement sans coût dans le chemin chaud.
 
+### Tier évitable canonique à l'archivage (1.1+)
+
+Le `n_plus_one_threshold` de l'opérateur décide quels patterns N+1 deviennent des findings, donc un seuil relâché réduit l'énergie/carbone évitable que la disclosure déclarerait. Comme `disclose` ne fait que sommer des chiffres déjà archivés et ne peut pas re-détecter (les findings supprimés par un seuil élevé sont absents de l'archive), le chiffre non manipulable doit être produit là où les traces brutes existent encore : le chemin d'archivage du daemon.
+
+`score::canonical::compute_disclosure_waste` exécute une passe N+1 + redondant supplémentaire au seuil épinglé `DISCLOSURE_N_PLUS_ONE_THRESHOLD` (`2`) et rééchelonne l'énergie/carbone évitable depuis `operational_gco2` et `accounted_io_ops` du résumé opérationnel (pas de second calcul carbone complet). Il renvoie les deux tiers, archivés sur `Report.disclosure_waste` : `canonical` au seuil épinglé et `operational` à celui de l'opérateur. Le tableau de bord live et `findings_store` gardent la sémantique opérationnelle, donc seule l'archive de disclosure porte le tier canonique. L'aggregator replie les deux tiers dans `aggregate.canonical_waste` / `operational_waste`, les champs plats évitables étant des alias du tier canonique. La passe supplémentaire n'est payée que quand l'archivage est activé.
+
+Une amélioration différée estamperait le seuil canonique par fenêtre et réconcilierait à travers un parc de binaires hétérogène à l'agrégation. Aujourd'hui l'aggregator réconcilie les seuils par `max` et expose les binaires producteurs via `aggregate.binary_versions`.
+
+Le validator authentifie le *label* canonique (`canonical_waste.n_plus_one_threshold == 2`), pas la *magnitude* des chiffres archivés : une ligne NDJSON falsifiée peut porter le seuil 2 avec des compteurs dégonflés et passer quand même. C'est inhérent à un modèle d'auto-déclaration. Le `content_hash` (et l'attestation cosign optionnelle) lie l'intégrité du *rapport publié*. L'honnêteté des archives sources repose sur le `binary_hash` du binaire et la provenance SLSA, pas sur l'aggregator. Les compteurs issus des archives sont sommés avec `saturating_add`, pour qu'une valeur proche de `u64::MAX` forgée ne puisse pas faire déborder un total de période vers un petit nombre (sous-déclaré).
+
 ## TOML org-config
 
 Le TOML fourni par l'opérateur est un blueprint partiel pour les champs statiques d'un `PeriodicReport`. Il porte `organisation`, `methodology`, `scope_manifest` (sans les chiffres runtime) et `notes` optionnel. L'aggregator remplit les sections runtime (`aggregate`, `applications`, `integrity`).

--- a/docs/REPORTING.md
+++ b/docs/REPORTING.md
@@ -60,6 +60,15 @@ Only `--input` and `--org-config` stay required. The period, intent, and confide
 
 The preview needs an interactive terminal. Piping its output (no TTY) exits with a clear error rather than rendering.
 
+## Avoidable waste: canonical versus operational (1.1+)
+
+A report carries the total operational energy and carbon of the workload (span-derived, not tunable) plus two tiers of avoidable waste:
+
+- **Canonical** (`aggregate.canonical_waste`). Computed at a fixed N+1 threshold pinned in the binary (`2`), regardless of the operator's `[detection] n_plus_one_threshold`. This is the non-manipulable figure: raising your own threshold cannot shrink it. It is the headline avoidable number, and at the default operator threshold of `5` it is typically larger than what the operator's own dashboard shows.
+- **Operational** (`aggregate.operational_waste`). Computed at the operator's configured threshold and recorded with that threshold.
+
+Publishing both keeps the disclosure honest: a reader compares the two and sees how much avoidable waste a loose operator threshold would otherwise hide. For `intent = official`, the validator rejects a report whose `canonical_waste.n_plus_one_threshold` is not the binary's canonical value.
+
 ![disclose preview, month view: settings header, aggregated summary, and the equivalent command in the footer](https://raw.githubusercontent.com/robintra/perf-sentinel/main/docs/img/disclose/preview.png)
 
 ![disclose preview, quarter view: the `g` stepper widens the period to the whole quarter](https://raw.githubusercontent.com/robintra/perf-sentinel/main/docs/img/disclose/quarter.png)

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,12 +1,14 @@
-# Schema reference: perf-sentinel-report v1.0
+# Schema reference: perf-sentinel-report v1.1
 
 This document describes the JSON shape of a periodic disclosure report in prose. The machine-readable JSON Schema lives at `docs/schemas/perf-sentinel-report-v1.json` (draft 2020-12). Two filled examples sit under `docs/schemas/examples/`.
+
+v1.1 adds the `canonical_waste` and `operational_waste` tiers to `aggregate`. The schema accepts both `perf-sentinel-report/v1.0` and `v1.1`, and the new fields default when absent, so v1.0 readers and reports remain valid.
 
 ## Top-level keys
 
 | key               | type           | required | notes                                                                    |
 |-------------------|----------------|----------|--------------------------------------------------------------------------|
-| `schema_version`  | string (const) | yes      | `"perf-sentinel-report/v1.0"`                                            |
+| `schema_version`  | string (enum)  | yes      | `"perf-sentinel-report/v1.1"` (also accepts `"…/v1.0"`)                  |
 | `report_metadata` | object         | yes      | see [Report metadata](#report-metadata)                                  |
 | `organisation`    | object         | yes      | see [Organisation](#organisation)                                        |
 | `period`          | object         | yes      | see [Period](#period)                                                    |
@@ -50,6 +52,15 @@ The publication domain (e.g. `transparency.example.fr`) is treated as an implici
 > **See also.** The [Energy and SCI primer](METHODOLOGY.md#background-energy-and-sci-primer) in the methodology doc defines SCI v1.0 terms (E, I, M), `efficiency_score`, `io_waste_ratio`, Scaphandre, SPECpower and the related vocabulary used by every field below.
 
 Sums across the entire period and the entire `applications` array. `total_requests`, `total_energy_kwh`, `total_carbon_kgco2eq`, and `estimated_optimization_potential_kgco2eq` are non-negative finite numbers. `aggregate_waste_ratio` is in `[0, 1]`. `aggregate_efficiency_score` is in `[0, 100]` and equals `clamp(100 - 100 * io_waste_ratio, 0, 100)`. `anti_patterns_detected_count` is the sum of every per-service occurrences count, including non-avoidable patterns.
+
+### Waste tiers (1.1+)
+
+The report carries the avoidable energy and carbon at two N+1 detection thresholds, side by side, so the gap between them is auditable:
+
+- `canonical_waste` is computed at a fixed N+1 threshold pinned in the binary (`2`), not the operator's config. It is the non-manipulable figure: an operator cannot shrink it by loosening their own threshold. This is the headline avoidable number, and the flat `estimated_optimization_potential_kgco2eq`, `aggregate_waste_ratio`, and `aggregate_efficiency_score` fields alias this tier since v1.1 (they carried the operational value in v1.0).
+- `operational_waste` is computed at the operator's configured N+1 threshold and records that threshold in `n_plus_one_threshold`. Comparing it against `canonical_waste` shows how much avoidable waste the operator's threshold hides.
+
+Each tier carries `n_plus_one_threshold` (integer), `energy_kwh` and `carbon_kgco2eq` (non-negative), `waste_ratio` (`[0, 1]`), and `efficiency_score` (`[0, 100]`). For `intent = "official"`, the validator requires `canonical_waste.n_plus_one_threshold` to equal the binary's canonical threshold; the operational threshold is the operator's recorded choice and is deliberately not range-checked, since a loose threshold is exactly what that tier exists to surface. The total energy and carbon (`total_energy_kwh`, `total_carbon_kgco2eq`) are span-derived and independent of either threshold.
 
 ### Quality signals (0.7.0+)
 

--- a/docs/ci-templates/github-actions-baseline.yml
+++ b/docs/ci-templates/github-actions-baseline.yml
@@ -41,7 +41,7 @@ jobs:
     name: Publish trunk baseline to gh-pages
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.8.1"
+      PERF_SENTINEL_VERSION: "0.8.2"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/github-actions.yml
+++ b/docs/ci-templates/github-actions.yml
@@ -63,7 +63,7 @@ jobs:
     name: Performance anti-pattern scan
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.8.1"
+      PERF_SENTINEL_VERSION: "0.8.2"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/gitlab-ci.yml
+++ b/docs/ci-templates/gitlab-ci.yml
@@ -23,7 +23,7 @@ stages:
   - perf-sentinel
 
 variables:
-  PERF_SENTINEL_VERSION: "0.8.1"
+  PERF_SENTINEL_VERSION: "0.8.2"
   PERF_SENTINEL_TRACES: "test-traces.json"
   PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/jenkinsfile.groovy
+++ b/docs/ci-templates/jenkinsfile.groovy
@@ -66,7 +66,7 @@ pipeline {
     }
 
     environment {
-        PERF_SENTINEL_VERSION = '0.8.1'
+        PERF_SENTINEL_VERSION = '0.8.2'
         PERF_SENTINEL_TRACES  = 'target/traces.json'
         PERF_SENTINEL_CONFIG  = '.perf-sentinel.toml'
     }

--- a/docs/design/08-PERIODIC-DISCLOSURE.md
+++ b/docs/design/08-PERIODIC-DISCLOSURE.md
@@ -97,6 +97,16 @@ The aggregator needs `green_summary` (for energy/carbon) and `per_endpoint_io_op
 
 `per_endpoint_io_ops` was previously bound to `_` in `process_traces` (the value was already computed by `score_green` but discarded). Keeping it for the archive is a no-cost change in the hot path.
 
+### Canonical avoidable tier at archive time (1.1+)
+
+The operator's `n_plus_one_threshold` decides which N+1 patterns become findings, so a loose threshold shrinks the avoidable energy/carbon the disclosure would report. Because `disclose` only sums pre-archived figures and cannot re-detect (findings suppressed by a high threshold are absent from the archive), the non-manipulable figure has to be produced where the raw traces still exist: the daemon archive path.
+
+`score::canonical::compute_disclosure_waste` runs one extra N+1 + redundant pass at the binary-pinned `DISCLOSURE_N_PLUS_ONE_THRESHOLD` (`2`) and rescales the avoidable energy/carbon from the operational summary's `operational_gco2` and `accounted_io_ops` (no second full carbon pass). It returns both tiers, archived on `Report.disclosure_waste`: `canonical` at the pinned threshold and `operational` at the operator's. The live dashboard and `findings_store` keep operational semantics, so only the disclosure archive carries the canonical tier. The aggregator folds both tiers into `aggregate.canonical_waste` / `operational_waste`, with the flat avoidable fields aliasing the canonical tier. The extra pass is paid only when archiving is enabled.
+
+A deferred upgrade would stamp the canonical threshold per window and reconcile across a heterogeneous binary fleet at aggregation time; today the aggregator reconciles thresholds by `max` and surfaces the producing binaries via `aggregate.binary_versions`.
+
+The validator authenticates the canonical *label* (`canonical_waste.n_plus_one_threshold == 2`), not the *magnitude* of the archived figures: a tampered NDJSON line can carry threshold 2 with deflated counts and still pass. This is inherent to a self-disclosure model. The `content_hash` (plus the optional cosign attestation) binds the integrity of the *published report*; the honesty of the source archives rests on the binary's `binary_hash` and SLSA provenance, not on the aggregator. Archive-derived counts are summed with `saturating_add` so a crafted near-`u64::MAX` value cannot wrap a period total into a small (under-reported) number.
+
 ## Org-config TOML
 
 The operator-supplied TOML is a partial blueprint for the static fields of a `PeriodicReport`. It carries `organisation`, `methodology`, `scope_manifest` (less the runtime numbers), and optional `notes`. The aggregator fills in the runtime sections (`aggregate`, `applications`, `integrity`).

--- a/docs/schemas/examples/example-internal-G1.json
+++ b/docs/schemas/examples/example-internal-G1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "perf-sentinel-report/v1.0",
+  "schema_version": "perf-sentinel-report/v1.1",
   "report_metadata": {
     "intent": "internal",
     "confidentiality_level": "internal",
@@ -81,6 +81,20 @@
     "aggregate_waste_ratio": 0.18,
     "anti_patterns_detected_count": 47,
     "estimated_optimization_potential_kgco2eq": 0.34,
+    "canonical_waste": {
+      "n_plus_one_threshold": 2,
+      "energy_kwh": 3.27,
+      "carbon_kgco2eq": 0.34,
+      "waste_ratio": 0.18,
+      "efficiency_score": 82.1
+    },
+    "operational_waste": {
+      "n_plus_one_threshold": 5,
+      "energy_kwh": 1.84,
+      "carbon_kgco2eq": 0.19,
+      "waste_ratio": 0.10,
+      "efficiency_score": 90.0
+    },
     "period_coverage": 0.94,
     "binary_versions": ["0.6.2", "0.7.0"],
     "runtime_windows_count": 169,

--- a/docs/schemas/examples/example-internal-G1.json
+++ b/docs/schemas/examples/example-internal-G1.json
@@ -183,7 +183,7 @@
   "integrity": {
     "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "binary_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.7.2",
+    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.8.2",
     "trace_integrity_chain": null,
     "signature": null
   },

--- a/docs/schemas/examples/example-official-public-G2.json
+++ b/docs/schemas/examples/example-official-public-G2.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "perf-sentinel-report/v1.0",
+  "schema_version": "perf-sentinel-report/v1.1",
   "report_metadata": {
     "intent": "official",
     "confidentiality_level": "public",
@@ -82,6 +82,20 @@
     "aggregate_waste_ratio": 0.18,
     "anti_patterns_detected_count": 47,
     "estimated_optimization_potential_kgco2eq": 0.34,
+    "canonical_waste": {
+      "n_plus_one_threshold": 2,
+      "energy_kwh": 3.27,
+      "carbon_kgco2eq": 0.34,
+      "waste_ratio": 0.18,
+      "efficiency_score": 82.1
+    },
+    "operational_waste": {
+      "n_plus_one_threshold": 5,
+      "energy_kwh": 1.84,
+      "carbon_kgco2eq": 0.19,
+      "waste_ratio": 0.10,
+      "efficiency_score": 90.0
+    },
     "period_coverage": 0.91,
     "binary_versions": ["0.7.0"],
     "runtime_windows_count": 164,

--- a/docs/schemas/examples/example-official-public-G2.json
+++ b/docs/schemas/examples/example-official-public-G2.json
@@ -146,7 +146,7 @@
   "integrity": {
     "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "binary_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.7.2",
+    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.8.2",
     "trace_integrity_chain": null,
     "signature": null
   },

--- a/docs/schemas/perf-sentinel-report-v1.json
+++ b/docs/schemas/perf-sentinel-report-v1.json
@@ -20,7 +20,7 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "const": "perf-sentinel-report/v1.0"
+      "enum": ["perf-sentinel-report/v1.0", "perf-sentinel-report/v1.1"]
     },
     "report_metadata": { "$ref": "#/$defs/ReportMetadata" },
     "organisation": { "$ref": "#/$defs/Organisation" },
@@ -290,6 +290,23 @@
         }
       }
     },
+    "WasteTier": {
+      "type": "object",
+      "required": [
+        "n_plus_one_threshold",
+        "energy_kwh",
+        "carbon_kgco2eq",
+        "waste_ratio",
+        "efficiency_score"
+      ],
+      "properties": {
+        "n_plus_one_threshold": { "type": "integer", "minimum": 0 },
+        "energy_kwh": { "type": "number", "minimum": 0 },
+        "carbon_kgco2eq": { "type": "number", "minimum": 0 },
+        "waste_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "efficiency_score": { "type": "number", "minimum": 0, "maximum": 100 }
+      }
+    },
     "Aggregate": {
       "type": "object",
       "required": [
@@ -319,6 +336,14 @@
         "estimated_optimization_potential_kgco2eq": {
           "type": "number",
           "minimum": 0
+        },
+        "canonical_waste": {
+          "$ref": "#/$defs/WasteTier",
+          "description": "Avoidable energy/carbon at the binary-pinned canonical N+1 threshold (non-manipulable by operator config). The flat aggregate_* and estimated_optimization_potential_kgco2eq fields alias this tier. v1.1+."
+        },
+        "operational_waste": {
+          "$ref": "#/$defs/WasteTier",
+          "description": "Avoidable energy/carbon at the operator's configured N+1 threshold, recorded with that threshold so the gap to canonical_waste is visible. v1.1+."
         },
         "period_coverage": {
           "type": "number",

--- a/release-gate/lab-validations.txt
+++ b/release-gate/lab-validations.txt
@@ -17,3 +17,7 @@ v0.7.7	4a39375	2026-05-27	PASS
 v0.7.8	525541f	2026-05-28	PASS
 v0.8.0	05f5af4	2026-05-29	PASS
 v0.8.1	3da90a0	2026-05-30	PASS
+# v0.8.2 initial candidate (6cf4eab) FAILED verify-hash on untampered official
+# disclosures: content_hash drifted 1 ULP on JSON re-parse. Fixed at c84c1e4
+# (serde_json float_roundtrip), re-validated green end-to-end.
+v0.8.2	fa53b74	2026-06-05	PASS


### PR DESCRIPTION
## Summary

Release 0.8.2. The periodic public disclosure now reports avoidable energy and carbon at two N+1 thresholds side by side, a binary-pinned canonical threshold the operator cannot configure and the operator's own configured threshold, so the disclosed waste figure can no longer be shrunk by loosening detection. The release also bumps the TUI backend and fixes a `content_hash` round-trip defect that the simulation lab surfaced in `verify-hash`.

## Changes

- **Disclosure two-tier avoidable waste (schema `perf-sentinel-report/v1.1`).** `disclose` now emits `aggregate.canonical_waste` (computed at a binary-pinned N+1 threshold of `2`, not operator-configurable, so it is non-manipulable) and `aggregate.operational_waste` (the operator's configured threshold), each carrying `energy_kwh`, `carbon_kgco2eq`, `waste_ratio` and `efficiency_score`. The canonical tier is computed at daemon archive time over the raw traces, and `disclose` folds both tiers from the archived NDJSON. The pre-existing flat avoidable fields alias the canonical tier. The change is additive, so v1.0 readers and reports stay valid. Adds `score/canonical.rs`, the two-tier aggregator fold, a validator rule pinning the canonical threshold for official intent, and the `Report.disclosure_waste` archive carrier.
- **`fix(disclose)`: `content_hash` survives `verify-hash`.** Enabled serde_json `float_roundtrip` so a float cannot drift by 1 ULP on JSON re-parse and break the hash of an untampered official disclosure. Surfaced by the simulation-lab validation, covered by a deterministic regression test.
- **`chore(deps)`: ratatui 0.30.0 to 0.30.1** (widget panic and overflow hardening, `Paragraph` alignment fix). No visual change for the list and paragraph TUI views.
- **`chore(cli)`: silenced two daemon-gated clippy false positives** (`unused_async`, `manual_map`) on the `--no-default-features` build.
- **Release bump to 0.8.2 / chart 0.2.47** (workspace version, intra-workspace pin, `PERF_SENTINEL_VERSION` in `docs/ci-templates/` and the `docs/CI.md` / `docs/FR/CI-FR.md` snippets, `Chart.yaml` appVersion and Artifact Hub annotations).
- **Docs**: `docs/SCHEMA.md`, `docs/REPORTING.md`, `docs/design/08-PERIODIC-DISCLOSURE.md` and their FR mirrors document the three tiers and the disclosure threat model.
- **Lab validation recorded**: `release-gate/lab-validations.txt` carries the `v0.8.2` PASS (10/10 findings, anti-gaming invariant confirmed, `verify-hash` green after the fix).

## Checklist

Cargo:

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Default-features build AND `--no-default-features` build both pass (daemon-gated code touched; `--no-default-features` clippy also green)

Documentation and assets:

- [x] Public-facing docs updated (`docs/` and `docs/FR/`: SCHEMA, REPORTING, design doc 08)
- [ ] Captures regenerated — n/a, no CLI default output, TUI, or HTML dashboard visual change (disclosure is JSON/schema, ratatui is a backend patch)
- [ ] `CHANGELOG.md` entry under `[Unreleased]` — left to the maintainer (root `CHANGELOG.md` is gitignored and maintainer-owned; the `[0.8.2]` entry is drafted. The tracked `charts/perf-sentinel/CHANGELOG.md` is updated.)

Versioning (release PR):

- [x] `workspace.package.version` bumped in root `Cargo.toml`
- [x] Intra-workspace `perf-sentinel-core` pin synced in `crates/sentinel-cli/Cargo.toml`
- [x] `PERF_SENTINEL_VERSION` synced in `docs/ci-templates/` and `docs/CI.md` / `docs/FR/CI-FR.md`
- [x] `charts/perf-sentinel/Chart.yaml` bumped in lockstep (version 0.2.47, appVersion 0.8.2)
- [x] `./scripts/check-tag-version.sh v0.8.2` passes locally

## Related issues

n/a
