### PR TITLE
release/0.8.4: man subcommand and usage-example help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,9 +310,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2272,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.2"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -2417,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2976,9 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags 2.12.1",
@@ -3196,9 +3196,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perf-sentinel"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "perf-sentinel-core"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clap_mangen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1731,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "clap_mangen",
  "crossterm",
  "humantime",
  "hyper",
@@ -2269,6 +2280,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rpassword"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sentinel-core", "crates/sentinel-cli"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 license = "AGPL-3.0-only"
 rust-version = "1.96.0"

--- a/README-FR.md
+++ b/README-FR.md
@@ -256,6 +256,7 @@ perf-sentinel tempo --endpoint http://tempo:3200 --trace-id <id>   # récup depu
 perf-sentinel jaeger-query --endpoint http://jaeger:16686 --service order-svc
 perf-sentinel calibrate --traces traces.json --measured-energy rapl.csv
 perf-sentinel completions zsh > ~/.zfunc/_perf-sentinel            # complétion shell
+perf-sentinel man > perf-sentinel.1                                # page de manuel
 perf-sentinel query findings --service order-svc                   # dialoguer avec un daemon
 ```
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ perf-sentinel tempo --endpoint http://tempo:3200 --trace-id <id>   # pull from G
 perf-sentinel jaeger-query --endpoint http://jaeger:16686 --service order-svc
 perf-sentinel calibrate --traces traces.json --measured-energy rapl.csv
 perf-sentinel completions zsh > ~/.zfunc/_perf-sentinel            # shell completions
+perf-sentinel man > perf-sentinel.1                                # man page
 perf-sentinel query findings --service order-svc                   # talk to a running daemon
 ```
 

--- a/charts/perf-sentinel/CHANGELOG.md
+++ b/charts/perf-sentinel/CHANGELOG.md
@@ -6,6 +6,13 @@ Chart versions are independent from the perf-sentinel application
 versions, the chart's `appVersion` field tracks which daemon version is
 the default target.
 
+## [0.2.49]
+
+### Changed
+
+- `appVersion` bumped to `0.8.4` to track the new `man` subcommand (renders the manual page to stdout) and the usage-example blocks added to every user-facing command's `--help`. Template surface is unchanged, no migration needed beyond the chart bump. No config or daemon wire change.
+- `artifacthub.io/images` annotation bumped to `ghcr.io/robintra/perf-sentinel:0.8.4` to keep the Artifact Hub display metadata in lockstep with `appVersion`. Runtime image selection is unaffected (templates already resolve to `.Chart.AppVersion` when `values.yaml` `image.tag` is empty).
+
 ## [0.2.48]
 
 ### Changed

--- a/charts/perf-sentinel/Chart.yaml
+++ b/charts/perf-sentinel/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   pool saturation, serialized parallelizable calls, fanout. Scores I/O
   intensity per endpoint (GreenOps).
 type: application
-version: 0.2.48
-appVersion: "0.8.3"
+version: 0.2.49
+appVersion: "0.8.4"
 kubeVersion: ">=1.24.0-0"
 home: https://github.com/robintra/perf-sentinel
 icon: https://raw.githubusercontent.com/robintra/perf-sentinel/main/logo/logo-horizontal.svg
@@ -53,9 +53,11 @@ annotations:
       description: "appVersion 0.8.2: the periodic public disclosure reports avoidable energy and carbon at two N+1 thresholds side by side, canonical_waste (a threshold pinned in the binary that the operator cannot configure, so the disclosed waste figure is non-manipulable) and operational_waste (the operator's configured threshold), schema perf-sentinel-report/v1.1. The flat avoidable fields alias the canonical tier and the change is additive, v1.0 readers remain valid. Also bumps the TUI backend to ratatui 0.30.1. No chart template change, this bump only tracks the new appVersion."
     - kind: added
       description: "appVersion 0.8.3: the periodic public disclosure gains a temporal-coverage continuity signal (aggregate.temporal_coverage, schema perf-sentinel-report/v1.2) that reports how many of the declared period's calendar days carried measurements, so a reader can tell a continuously-measured period from one where the daemon ran only a few days. Archiving is traffic-gated so the figure is a lower bound on activity, not daemon uptime, surfaced as a warning and an in-band disclaimer, never a hard official gate. Also adds an in-band coverage_basis provenance marker and reserves an integrity.cross_period_log hook. The schema change is additive, v1.1 and v1.0 readers remain valid. No chart template change, this bump only tracks the new appVersion."
+    - kind: added
+      description: "appVersion 0.8.4: a man subcommand renders the perf-sentinel manual page to stdout (perf-sentinel man, backed by clap_mangen), mirroring the existing completions subcommand. Every user-facing command's --help now carries copy-pasteable usage examples, and several command help texts were tightened. No chart template change, this bump only tracks the new appVersion."
   artifacthub.io/images: |
     - name: perf-sentinel
-      image: ghcr.io/robintra/perf-sentinel:0.8.3
+      image: ghcr.io/robintra/perf-sentinel:0.8.4
       platforms:
         - linux/amd64
         - linux/arm64

--- a/crates/sentinel-cli/Cargo.toml
+++ b/crates/sentinel-cli/Cargo.toml
@@ -41,7 +41,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 serde = { version = "1.0.228", features = ["derive"] }
 # float_roundtrip: exact float parsing so verify-hash round-trips the
 # disclosure content_hash. See the note in sentinel-core/Cargo.toml.
-serde_json = { version = "1.0.149", features = ["float_roundtrip"] }
+serde_json = { version = "1.0.150", features = ["float_roundtrip"] }
 # Used to stamp the current time when applying acknowledgments. Same
 # version line as the core crate, default-features off to skip the
 # wasm/JS bindings.
@@ -59,7 +59,7 @@ crossterm = { version = "0.29.0", optional = true }
 hyper = { version = "1.9.0", optional = true }
 bytes = { version = "1.11.1", optional = true }
 humantime = { version = "2.3.0", optional = true }
-rpassword = { version = "7.5.2", optional = true }
+rpassword = { version = "7.5.4", optional = true }
 # Synchronous HTTP client used exclusively by `verify-hash --url`.
 # Sync (not tokio), small dep graph, audited (Cure53 2021). The default
 # `rustls` feature pulls in TLS support; no native-tls fallback.

--- a/crates/sentinel-cli/Cargo.toml
+++ b/crates/sentinel-cli/Cargo.toml
@@ -35,6 +35,7 @@ jaeger-query = ["perf-sentinel-core/jaeger-query"]
 perf-sentinel-core = { version = "0.8.3", path = "../sentinel-core" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap_complete = "4.6.5"
+clap_mangen = "0.3.0"
 tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/crates/sentinel-cli/Cargo.toml
+++ b/crates/sentinel-cli/Cargo.toml
@@ -32,7 +32,7 @@ tempo = ["perf-sentinel-core/tempo"]
 jaeger-query = ["perf-sentinel-core/jaeger-query"]
 
 [dependencies]
-perf-sentinel-core = { version = "0.8.3", path = "../sentinel-core" }
+perf-sentinel-core = { version = "0.8.4", path = "../sentinel-core" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap_complete = "4.6.5"
 clap_mangen = "0.3.0"

--- a/crates/sentinel-cli/src/disclose.rs
+++ b/crates/sentinel-cli/src/disclose.rs
@@ -1211,7 +1211,13 @@ pub fn cmd_disclose(
         return 2;
     }
 
-    emit_non_fatal_warnings(&report, intent_schema);
+    for warning in non_fatal_warnings(
+        &report.aggregate.temporal_coverage,
+        intent_schema,
+        report.scope_manifest.total_requests_in_period.is_some(),
+    ) {
+        eprintln!("{warning}");
+    }
 
     match compute_content_hash(&report) {
         Ok(hash) => {
@@ -1254,29 +1260,34 @@ pub fn cmd_disclose(
 
 // Non-fatal continuity + completeness warnings. temporal_coverage is never
 // a hard gate (archiving is traffic-gated, so a low value can be a quiet
-// period), only surfaced here and as an in-band disclaimer.
-fn emit_non_fatal_warnings(report: &PeriodicReport, intent: ReportIntent) {
-    let tc = &report.aggregate.temporal_coverage;
-    if tc.temporal_coverage < LOW_TEMPORAL_COVERAGE_WARN_THRESHOLD {
-        eprintln!(
+// period), only surfaced here and as an in-band disclaimer. Pure (returns the
+// lines) so it is unit-testable, cmd_disclose prints them to stderr.
+fn non_fatal_warnings(
+    coverage: &TemporalCoverage,
+    intent: ReportIntent,
+    total_requests_declared: bool,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if coverage.temporal_coverage < LOW_TEMPORAL_COVERAGE_WARN_THRESHOLD {
+        warnings.push(format!(
             "Warning: temporal coverage is {:.1}% ({}/{} declared days had measured \
              traffic, largest gap {} {}). Archiving is traffic-gated, so quiet \
              periods lower this, it is not a daemon-uptime guarantee.",
-            tc.temporal_coverage * 100.0,
-            tc.observed_days,
-            tc.days_in_period,
-            tc.largest_gap_days,
-            day_or_days(tc.largest_gap_days),
-        );
+            coverage.temporal_coverage * 100.0,
+            coverage.observed_days,
+            coverage.days_in_period,
+            coverage.largest_gap_days,
+            day_or_days(coverage.largest_gap_days),
+        ));
     }
-    if matches!(intent, ReportIntent::Official)
-        && report.scope_manifest.total_requests_in_period.is_none()
-    {
-        eprintln!(
+    if matches!(intent, ReportIntent::Official) && !total_requests_declared {
+        warnings.push(
             "Warning: total_requests_in_period is not declared in the org config; \
              coverage_percentage will be absent from this official report."
+                .to_string(),
         );
     }
+    warnings
 }
 
 fn write_attestation(
@@ -1810,5 +1821,45 @@ mod tests {
 
         let _ = std::fs::remove_file(&tmp);
         let _ = std::fs::remove_file(&att);
+    }
+
+    #[test]
+    fn non_fatal_warnings_flags_low_coverage_and_undeclared_official_requests() {
+        let low = TemporalCoverage {
+            temporal_coverage: 0.10,
+            observed_days: 3,
+            days_in_period: 30,
+            largest_gap_days: 20,
+        };
+        let warnings = non_fatal_warnings(&low, ReportIntent::Official, false);
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings[0].contains("temporal coverage is 10.0%"));
+        assert!(warnings[0].contains("3/30 declared days"));
+        assert!(warnings[0].contains("largest gap 20 days"));
+        assert!(warnings[1].contains("total_requests_in_period is not declared"));
+    }
+
+    #[test]
+    fn non_fatal_warnings_silent_when_healthy_and_declared() {
+        let healthy = TemporalCoverage {
+            temporal_coverage: 1.0,
+            observed_days: 30,
+            days_in_period: 30,
+            largest_gap_days: 0,
+        };
+        // Full coverage and a declared request count: an official report stays quiet.
+        assert!(non_fatal_warnings(&healthy, ReportIntent::Official, true).is_empty());
+    }
+
+    #[test]
+    fn non_fatal_warnings_internal_intent_never_warns_on_requests() {
+        let healthy = TemporalCoverage {
+            temporal_coverage: 1.0,
+            observed_days: 30,
+            days_in_period: 30,
+            largest_gap_days: 0,
+        };
+        // Internal intent skips the total_requests_in_period warning even when undeclared.
+        assert!(non_fatal_warnings(&healthy, ReportIntent::Internal, false).is_empty());
     }
 }

--- a/crates/sentinel-cli/src/disclose.rs
+++ b/crates/sentinel-cli/src/disclose.rs
@@ -1211,30 +1211,7 @@ pub fn cmd_disclose(
         return 2;
     }
 
-    // Non-fatal continuity + completeness warnings. temporal_coverage is never
-    // a hard gate (archiving is traffic-gated, so a low value can be a quiet
-    // period), only surfaced here and as an in-band disclaimer.
-    let tc = &report.aggregate.temporal_coverage;
-    if tc.temporal_coverage < LOW_TEMPORAL_COVERAGE_WARN_THRESHOLD {
-        eprintln!(
-            "Warning: temporal coverage is {:.1}% ({}/{} declared days had measured \
-             traffic, largest gap {} {}). Archiving is traffic-gated, so quiet \
-             periods lower this, it is not a daemon-uptime guarantee.",
-            tc.temporal_coverage * 100.0,
-            tc.observed_days,
-            tc.days_in_period,
-            tc.largest_gap_days,
-            day_or_days(tc.largest_gap_days),
-        );
-    }
-    if matches!(intent_schema, ReportIntent::Official)
-        && report.scope_manifest.total_requests_in_period.is_none()
-    {
-        eprintln!(
-            "Warning: total_requests_in_period is not declared in the org config; \
-             coverage_percentage will be absent from this official report."
-        );
-    }
+    emit_non_fatal_warnings(&report, intent_schema);
 
     match compute_content_hash(&report) {
         Ok(hash) => {
@@ -1273,6 +1250,33 @@ pub fn cmd_disclose(
         report.applications.len()
     );
     0
+}
+
+// Non-fatal continuity + completeness warnings. temporal_coverage is never
+// a hard gate (archiving is traffic-gated, so a low value can be a quiet
+// period), only surfaced here and as an in-band disclaimer.
+fn emit_non_fatal_warnings(report: &PeriodicReport, intent: ReportIntent) {
+    let tc = &report.aggregate.temporal_coverage;
+    if tc.temporal_coverage < LOW_TEMPORAL_COVERAGE_WARN_THRESHOLD {
+        eprintln!(
+            "Warning: temporal coverage is {:.1}% ({}/{} declared days had measured \
+             traffic, largest gap {} {}). Archiving is traffic-gated, so quiet \
+             periods lower this, it is not a daemon-uptime guarantee.",
+            tc.temporal_coverage * 100.0,
+            tc.observed_days,
+            tc.days_in_period,
+            tc.largest_gap_days,
+            day_or_days(tc.largest_gap_days),
+        );
+    }
+    if matches!(intent, ReportIntent::Official)
+        && report.scope_manifest.total_requests_in_period.is_none()
+    {
+        eprintln!(
+            "Warning: total_requests_in_period is not declared in the org config; \
+             coverage_percentage will be absent from this official report."
+        );
+    }
 }
 
 fn write_attestation(

--- a/crates/sentinel-cli/src/main.rs
+++ b/crates/sentinel-cli/src/main.rs
@@ -499,6 +499,13 @@ enum Commands {
         #[arg(value_enum)]
         shell: Shell,
     },
+    /// Generate a man page for perf-sentinel on stdout.
+    ///
+    /// Renders the roff man page for the top-level command (it lists the
+    /// subcommands, like `git.1`). Redirect it into your man path, e.g.
+    /// `perf-sentinel man > /usr/local/share/man/man1/perf-sentinel.1`.
+    #[command(after_help = help_examples::MAN)]
+    Man,
     /// Produce a periodic public disclosure report (v1.2 schema).
     ///
     /// Reads archived per-window `Report` NDJSON, filters to the
@@ -824,6 +831,10 @@ mod help_examples {
 
   # Install bash completions
   perf-sentinel completions bash > /usr/local/etc/bash_completion.d/perf-sentinel";
+
+    pub const MAN: &str = "Examples:
+  # Install the man page into the system man path
+  perf-sentinel man > /usr/local/share/man/man1/perf-sentinel.1";
 }
 
 #[tokio::main]
@@ -1091,6 +1102,13 @@ async fn dispatch_command(command: Commands) {
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();
             clap_complete::generate(shell, &mut cmd, "perf-sentinel", &mut std::io::stdout());
+        }
+        Commands::Man => {
+            let cmd = Cli::command();
+            if let Err(err) = clap_mangen::Man::new(cmd).render(&mut std::io::stdout()) {
+                eprintln!("Error: failed to render man page: {err}");
+                std::process::exit(1);
+            }
         }
         Commands::Disclose {
             intent,
@@ -3005,6 +3023,30 @@ mod tests {
         assert!(
             result.is_err(),
             "tcsh is not a clap_complete::Shell variant"
+        );
+    }
+
+    #[test]
+    fn man_subcommand_parses() {
+        let cli = Cli::try_parse_from(["perf-sentinel", "man"]).expect("failed to parse 'man'");
+        assert!(matches!(cli.command, Commands::Man));
+    }
+
+    #[test]
+    fn man_subcommand_renders_roff() {
+        use clap::CommandFactory;
+        let mut buf: Vec<u8> = Vec::new();
+        clap_mangen::Man::new(Cli::command())
+            .render(&mut buf)
+            .expect("man render should succeed");
+        let out = String::from_utf8(buf).expect("man output is utf-8");
+        assert!(
+            out.contains(".TH"),
+            "man page should carry a .TH roff header"
+        );
+        assert!(
+            out.to_uppercase().contains("PERF-SENTINEL"),
+            "man page should name the binary"
         );
     }
 }

--- a/crates/sentinel-cli/src/main.rs
+++ b/crates/sentinel-cli/src/main.rs
@@ -103,7 +103,7 @@ enum Commands {
         #[arg(long)]
         show_acknowledged: bool,
         /// Launch the interactive TUI instead of printing the report.
-        /// Opens on the Analyze view; Enter drills down to Inspect then
+        /// Opens on the Analyze view. Enter drills down to Inspect then
         /// Explain, Esc walks back up.
         #[cfg(feature = "tui")]
         #[arg(long, conflicts_with_all = ["ci", "format", "show_acknowledged"])]
@@ -137,7 +137,7 @@ enum Commands {
 
     /// Explain a specific trace: tree view with findings annotated inline.
     /// Span-anchored detections (N+1, redundant, slow, fanout) land on
-    /// their offending spans; trace-level detections (chatty service,
+    /// their offending spans. Trace-level detections (chatty service,
     /// pool saturation, serialized calls) are rendered in a dedicated
     /// header section above the span tree. Cross-trace percentile
     /// findings from `analyze` are not included.
@@ -155,7 +155,7 @@ enum Commands {
         #[arg(long, value_enum, default_value = "text")]
         format: ExplainFormat,
         /// Launch the interactive TUI instead of printing the tree.
-        /// Opens on the Explain view focused on --trace-id; Esc walks up
+        /// Opens on the Explain view focused on --trace-id. Esc walks up
         /// to the Inspect and Analyze views.
         #[cfg(feature = "tui")]
         #[arg(long, conflicts_with = "format")]
@@ -178,7 +178,7 @@ enum Commands {
     /// native, Jaeger or Zipkin) or a pre-computed Report JSON
     /// (e.g. a daemon snapshot from `/api/export/report`). With a
     /// Report input the Findings and Correlations panels light up
-    /// fully; the Detail panel falls back to per-trace stubs because
+    /// fully. The Detail panel falls back to per-trace stubs because
     /// Reports do not carry raw spans.
     #[cfg(feature = "tui")]
     Inspect {
@@ -420,7 +420,7 @@ enum Commands {
         /// --pg-stat-prometheus.
         ///
         /// Accepts values in `[1, 10000]`. Values above ~1000 rarely
-        /// add insight and stress the upstream exporter; the
+        /// add insight and stress the upstream exporter. The
         /// `postgres_exporter` default query timeout is 30s.
         /// Supplying this flag without a `pg_stat` source errors
         /// with a message pointing at the required companion flag.
@@ -495,9 +495,9 @@ enum Commands {
     /// writes a single `perf-sentinel-report.json`. Designed for public
     /// transparency, not regulatory-grade.
     Disclose {
-        /// `internal`, `official`, or `audited`. `audited` short-circuits
-        /// with exit code 2 in this release. Optional under `--tui` (set
-        /// it live in the preview).
+        /// `internal`, `official`, or `audited`. `audited` is reserved for
+        /// a future release and exits with code 2. Optional under `--tui`
+        /// (set it live in the preview).
         #[cfg_attr(
             feature = "tui",
             arg(long, value_enum, required_unless_present = "tui")

--- a/crates/sentinel-cli/src/main.rs
+++ b/crates/sentinel-cli/src/main.rs
@@ -79,6 +79,7 @@ enum Commands {
     /// window correlator and are not available in batch analyze. Use
     /// `perf-sentinel watch` then `perf-sentinel query correlations`
     /// for cross-trace findings.
+    #[command(after_help = help_examples::ANALYZE)]
     Analyze {
         /// Path to a JSON trace file to analyze. If omitted, reads from stdin.
         #[arg(short, long)]
@@ -112,6 +113,7 @@ enum Commands {
 
     /// Watch for traces in real-time (daemon mode).
     #[cfg(feature = "daemon")]
+    #[command(after_help = help_examples::WATCH)]
     Watch {
         /// Path to a .perf-sentinel.toml config file.
         #[arg(short, long)]
@@ -141,6 +143,7 @@ enum Commands {
     /// pool saturation, serialized calls) are rendered in a dedicated
     /// header section above the span tree. Cross-trace percentile
     /// findings from `analyze` are not included.
+    #[command(after_help = help_examples::EXPLAIN)]
     Explain {
         /// Path to a JSON trace file.
         #[arg(short, long)]
@@ -199,6 +202,7 @@ enum Commands {
 
     /// Query Grafana Tempo for traces and analyze them.
     #[cfg(feature = "tempo")]
+    #[command(after_help = help_examples::TEMPO)]
     Tempo {
         /// Tempo HTTP API endpoint (e.g. `http://localhost:3200`).
         #[arg(long)]
@@ -247,6 +251,7 @@ enum Commands {
 
     /// Query a Jaeger query API backend (Jaeger or Victoria Traces) for traces and analyze them.
     #[cfg(feature = "jaeger-query")]
+    #[command(after_help = help_examples::JAEGER_QUERY)]
     JaegerQuery {
         /// Jaeger query API endpoint (e.g. `http://localhost:16686` or `http://victoria:10428`).
         #[arg(long)]
@@ -294,6 +299,7 @@ enum Commands {
     },
 
     /// Calibrate energy coefficients from real measurements.
+    #[command(after_help = help_examples::CALIBRATE)]
     Calibrate {
         /// Path to a JSON trace file (same format as analyze input).
         #[arg(long)]
@@ -310,6 +316,7 @@ enum Commands {
     },
 
     /// Analyze `pg_stat_statements` data for SQL hotspot detection.
+    #[command(after_help = help_examples::PG_STAT)]
     PgStat {
         /// Path to `pg_stat_statements` CSV or JSON export.
         #[arg(short, long)]
@@ -340,6 +347,7 @@ enum Commands {
 
     /// Query a running perf-sentinel daemon for findings and status.
     #[cfg(feature = "daemon")]
+    #[command(after_help = help_examples::QUERY)]
     Query {
         /// Daemon HTTP endpoint.
         #[arg(long, default_value = "http://localhost:4318")]
@@ -356,6 +364,7 @@ enum Commands {
     /// is a TTY. TOML CI acks (`.perf-sentinel-acknowledgments.toml`)
     /// are out of scope, edit the file and ship via PR review instead.
     #[cfg(feature = "daemon")]
+    #[command(after_help = help_examples::ACK)]
     Ack {
         /// Daemon HTTP endpoint.
         #[arg(
@@ -375,6 +384,7 @@ enum Commands {
     /// even when the quality gate fails (the gate status is rendered as
     /// a badge in the HTML top bar, not as a CI signal). Use `analyze
     /// --ci` for the exit-code semantics.
+    #[command(after_help = help_examples::REPORT)]
     Report {
         /// Path to a JSON trace file. Omit or pass `-` to read from stdin.
         /// Same format auto-detection as `analyze --input` (native JSON,
@@ -453,6 +463,7 @@ enum Commands {
     },
 
     /// Compare two trace sets and emit a delta report (regressions and improvements).
+    #[command(after_help = help_examples::DIFF)]
     Diff {
         /// Path to the baseline trace file (e.g. base branch, last release).
         #[arg(long)]
@@ -482,6 +493,7 @@ enum Commands {
     ///
     /// Pipe the output to the shell-specific completion path, e.g.
     /// `perf-sentinel completions zsh > ~/.zfunc/_perf-sentinel`.
+    #[command(after_help = help_examples::COMPLETIONS)]
     Completions {
         /// Target shell: bash, zsh, fish, powershell, elvish.
         #[arg(value_enum)]
@@ -494,6 +506,7 @@ enum Commands {
     /// applicable, computes the deterministic SHA-256 content hash, and
     /// writes a single `perf-sentinel-report.json`. Designed for public
     /// transparency, not regulatory-grade.
+    #[command(after_help = help_examples::DISCLOSE)]
     Disclose {
         /// `internal`, `official`, or `audited`. `audited` is reserved for
         /// a future release and exits with code 2. Optional under `--tui`
@@ -580,6 +593,7 @@ enum Commands {
     /// at the matching sidecar files, delegates signature verification
     /// to `cosign verify-blob` and SLSA verification to
     /// `gh attestation verify`.
+    #[command(after_help = help_examples::VERIFY_HASH)]
     VerifyHash {
         /// Local report file to verify. Required unless `--url` is set.
         #[arg(long, value_name = "PATH", conflicts_with = "url")]
@@ -627,6 +641,7 @@ enum Commands {
     /// saves the result to `--output`. The same path as `--report` is
     /// allowed and bakes in place via an atomic temp+rename. Intended
     /// for test fixture generation and debugging.
+    #[command(after_help = help_examples::HASH_BAKE)]
     HashBake {
         /// Local report file to read.
         #[arg(long, value_name = "PATH")]
@@ -710,6 +725,105 @@ enum QueryAction {
         #[arg(long, value_enum, default_value = "text")]
         format: QueryOutputFormat,
     },
+}
+
+/// Usage-example blocks appended under each user-facing command's help
+/// via clap `after_help`. Centralized so the examples stay in lockstep with
+/// the invocations documented in `docs/CLI.md` and the README. Feature-gated
+/// constants mirror their command's `#[cfg]` so no constant goes unused
+/// in a `--no-default-features` build.
+mod help_examples {
+    pub const ANALYZE: &str = "Examples:
+  # Gate a CI run and fail on regressions
+  perf-sentinel analyze --ci --input traces.json
+
+  # Emit JSON for a dashboard or further processing
+  perf-sentinel analyze --input traces.json --format json";
+
+    #[cfg(feature = "daemon")]
+    pub const WATCH: &str = "Examples:
+  # Run the daemon, listening on all interfaces for containers
+  perf-sentinel watch --listen-address 0.0.0.0
+
+  # Load thresholds and detection settings from a config file
+  perf-sentinel watch --config .perf-sentinel.toml";
+
+    pub const EXPLAIN: &str = "Examples:
+  # Render the annotated span tree for a single trace
+  perf-sentinel explain --input traces.json --trace-id abc123def456";
+
+    pub const REPORT: &str = "Examples:
+  # Build a self-contained HTML dashboard
+  perf-sentinel report --input traces.json --output report.html
+
+  # Add a Diff tab against a baseline report
+  perf-sentinel report --input traces.json --output report.html --before baseline.json";
+
+    pub const DIFF: &str = "Examples:
+  # Compare a PR against its baseline and emit SARIF for code scanning
+  perf-sentinel diff --before base.json --after pr.json --format sarif --output diff.sarif";
+
+    #[cfg(feature = "tempo")]
+    pub const TEMPO: &str = "Examples:
+  # Fetch and analyze a single trace
+  perf-sentinel tempo --endpoint http://tempo:3200 --trace-id abc123def456
+
+  # Search recent traces for a service
+  perf-sentinel tempo --endpoint http://tempo:3200 --service order-svc --lookback 2h";
+
+    #[cfg(feature = "jaeger-query")]
+    pub const JAEGER_QUERY: &str = "Examples:
+  # Pull recent traces for a service and analyze them
+  perf-sentinel jaeger-query --endpoint http://jaeger:16686 --service order-svc";
+
+    pub const CALIBRATE: &str = "Examples:
+  # Fit energy coefficients from measured power
+  perf-sentinel calibrate --traces traces.json --measured-energy rapl.csv";
+
+    pub const PG_STAT: &str = "Examples:
+  # Rank SQL hotspots from a pg_stat_statements export
+  perf-sentinel pg-stat --input pg_stat.csv --traces traces.json";
+
+    #[cfg(feature = "daemon")]
+    pub const QUERY: &str = "Examples:
+  # List recent findings for a service from a running daemon
+  perf-sentinel query findings --service order-svc
+
+  # Show daemon status
+  perf-sentinel query status";
+
+    #[cfg(feature = "daemon")]
+    pub const ACK: &str = "Examples:
+  # Acknowledge a finding for one week
+  perf-sentinel ack create --signature \"<signature>\" --reason \"deferred to next cycle\" --expires 7d
+
+  # List active daemon acknowledgments
+  perf-sentinel ack list";
+
+    pub const DISCLOSE: &str = "Examples:
+  # Aggregate a quarter of archived windows into an internal report
+  perf-sentinel disclose --intent internal --confidentiality internal --period-type calendar-quarter --from 2026-01-01 --to 2026-03-31 --input /var/lib/perf-sentinel/reports.ndjson --output report.json --org-config org.toml
+
+  # Public report with a signed attestation sidecar
+  perf-sentinel disclose --intent official --confidentiality public --period-type calendar-quarter --from 2026-01-01 --to 2026-03-31 --input archive/2026Q1/ --output report.json --emit-attestation report.intoto.jsonl --org-config org.toml";
+
+    pub const VERIFY_HASH: &str = "Examples:
+  # Verify a local report and its sidecar signature
+  perf-sentinel verify-hash --report report.json --attestation report.intoto.jsonl --bundle report.sig --expected-identity release@example.com --expected-issuer https://accounts.google.com
+
+  # Recompute the content hash of a published report
+  perf-sentinel verify-hash --url https://example.com/perf-sentinel-report.json --no-identity-check";
+
+    pub const HASH_BAKE: &str = "Examples:
+  # Bake the canonical content hash into a report in place
+  perf-sentinel hash-bake --report report.json --output report.json";
+
+    pub const COMPLETIONS: &str = "Examples:
+  # Install zsh completions
+  perf-sentinel completions zsh > ~/.zfunc/_perf-sentinel
+
+  # Install bash completions
+  perf-sentinel completions bash > /usr/local/etc/bash_completion.d/perf-sentinel";
 }
 
 #[tokio::main]

--- a/crates/sentinel-cli/tests/e2e.rs
+++ b/crates/sentinel-cli/tests/e2e.rs
@@ -114,6 +114,43 @@ fn cli_help_shows_subcommands() {
     assert!(stdout.contains("analyze"));
     assert_eq!(stdout.contains("watch"), cfg!(feature = "daemon"));
     assert!(stdout.contains("demo"));
+    // `contains("man")` would be vacuous: "Commands" already contains "man".
+    // Assert on the man subcommand's unique about string instead.
+    assert!(stdout.contains("Generate a man page"));
+}
+
+#[test]
+fn cli_man_outputs_roff_page() {
+    let output = Command::new(env!("CARGO_BIN_EXE_perf-sentinel"))
+        .arg("man")
+        .output()
+        .expect("failed to execute perf-sentinel");
+
+    assert!(output.status.success(), "man command failed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(".TH"),
+        "man output should carry a .TH roff header"
+    );
+    assert!(
+        stdout.to_uppercase().contains("PERF-SENTINEL"),
+        "man output should name the binary"
+    );
+}
+
+#[test]
+fn cli_analyze_help_shows_usage_examples() {
+    let output = Command::new(env!("CARGO_BIN_EXE_perf-sentinel"))
+        .args(["analyze", "--help"])
+        .output()
+        .expect("failed to execute perf-sentinel");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Examples:"),
+        "analyze --help should include a usage examples block"
+    );
+    assert!(stdout.contains("perf-sentinel analyze --ci --input traces.json"));
 }
 
 #[test]

--- a/crates/sentinel-core/Cargo.toml
+++ b/crates/sentinel-core/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0.228", features = ["derive", "rc"] }
 # serialized JSON, so a float must parse back to the exact same f64 on
 # verify-hash. The default serde_json parser can shift a value by 1 ULP,
 # breaking the hash of an untampered report. This feature makes parsing exact.
-serde_json = { version = "1.0.149", features = ["float_roundtrip"] }
+serde_json = { version = "1.0.150", features = ["float_roundtrip"] }
 tracing = "0.1.44"
 thiserror = "2.0.18"
 toml = "1.1.2"
@@ -62,12 +62,12 @@ lru = "0.18.0"
 # date parsing and the "is this ack still active" check
 # (`Utc::now()` comparison).
 sha2 = "0.11.0"
-chrono = { version = "0.4.44", default-features = false, features = ["clock", "serde"] }
+chrono = { version = "0.4.45", default-features = false, features = ["clock", "serde"] }
 # UUID v4 for the `report_uuid` field of periodic disclosure reports.
 # Serde feature lets the wire schema embed the value as a JSON string.
-uuid = { version = "1.23.1", features = ["v4", "serde"] }
+uuid = { version = "1.23.2", features = ["v4", "serde"] }
 # Daemon-only deps (behind the `daemon` feature flag).
-hyper = { version = "1.9.0", features = ["client", "http1", "server"], optional = true }
+hyper = { version = "1.10.1", features = ["client", "http1", "server"], optional = true }
 hyper-util = { version = "0.1.20", features = ["client", "client-legacy", "http1", "http2", "tokio", "server-auto"], optional = true }
 http-body-util = { version = "0.1.3", optional = true }
 bytes = { version = "1.11.1", optional = true }
@@ -77,7 +77,7 @@ tokio-rustls = { version = "0.26.4", optional = true, default-features = false, 
 
 tokio-stream = { version = "0.1.18", optional = true }
 # Provides RequestDecompressionLayer for OTLP/HTTP gzip decompression on /v1/traces.
-tower-http = { version = "0.6.10", features = ["cors", "decompression-gzip", "limit"], optional = true }
+tower-http = { version = "0.6.11", features = ["cors", "decompression-gzip", "limit"], optional = true }
 # Cross-platform locator for `~/.local/share/perf-sentinel/acks.jsonl`
 # (XDG on Linux, Library/Application Support on macOS, Roaming on Windows).
 # Daemon-only: only the ack store consumes it, batch builds skip the dep.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -434,7 +434,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.8.3"
+      PERF_SENTINEL_VERSION: "0.8.4"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -162,3 +162,22 @@ perf-sentinel completions fish > ~/.config/fish/completions/perf-sentinel.fish
 Reload your shell, or `source` the file, after install. Re-run the
 generator after upgrading `perf-sentinel` so completions stay in sync
 with new flags and subcommands.
+
+## Man page
+
+`perf-sentinel man` writes a roff man page to stdout. It renders the
+top-level page, which lists the subcommands (like `git.1`). Redirect it
+into your man path:
+
+```bash
+perf-sentinel man > /usr/local/share/man/man1/perf-sentinel.1
+```
+
+`man perf-sentinel` then works. To preview without installing:
+
+```bash
+perf-sentinel man > /tmp/perf-sentinel.1 && man /tmp/perf-sentinel.1
+```
+
+Re-run the generator after upgrading `perf-sentinel` so the page stays
+in sync with new flags and subcommands.

--- a/docs/FR/CI-FR.md
+++ b/docs/FR/CI-FR.md
@@ -486,7 +486,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.8.3"
+      PERF_SENTINEL_VERSION: "0.8.4"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/FR/CLI-FR.md
+++ b/docs/FR/CLI-FR.md
@@ -166,3 +166,23 @@ perf-sentinel completions fish > ~/.config/fish/completions/perf-sentinel.fish
 Recharger le shell, ou `source` le fichier, après l'installation.
 Régénérer le script après chaque upgrade de `perf-sentinel` pour que
 la complétion reste alignée avec les nouveaux flags et sous-commandes.
+
+## Page de manuel
+
+`perf-sentinel man` écrit une page de manuel roff sur stdout. Elle rend
+la page de premier niveau, qui liste les sous-commandes (comme `git.1`).
+Rediriger la sortie vers le chemin des pages de manuel :
+
+```bash
+perf-sentinel man > /usr/local/share/man/man1/perf-sentinel.1
+```
+
+`man perf-sentinel` fonctionne ensuite. Pour prévisualiser sans
+installer :
+
+```bash
+perf-sentinel man > /tmp/perf-sentinel.1 && man /tmp/perf-sentinel.1
+```
+
+Régénérer la page après chaque upgrade de `perf-sentinel` pour qu'elle
+reste alignée avec les nouveaux flags et sous-commandes.

--- a/docs/FR/RELEASE-PROCEDURE-FR.md
+++ b/docs/FR/RELEASE-PROCEDURE-FR.md
@@ -209,15 +209,6 @@ git push origin chart-vA.B.C
 
 L'un ou l'autre chemin déclenche `.github/workflows/helm-release.yml`, qui valide le tag du chart contre `Chart.yaml` via `scripts/check-helm-tag-version.sh`, package le chart et le pousse sur GHCR comme artefact OCI, le signe avec cosign en keyless, atteste la provenance de build SLSA et un SBOM SPDX (tous deux vérifiables via `gh attestation verify`), et crée la GitHub Release en brouillon. Publiez le brouillon une fois que vous l'avez relu.
 
-### 8. Communication publique
-
-Après que la page de release GitHub est générée et que le chart est live :
-
-- Post LinkedIn avec lien vers les release notes
-- Entrée de blog sur le site projet si la release introduit des capacités user-facing
-- Reddit, Hacker News, canaux communautaires quand le changement est largement pertinent
-- Contacts institutionnels (collaborateurs académiques, clients sous accord de disclosure) pour les releases qui touchent leurs cas d'usage
-
 ## Ce que fait le workflow de release
 
 À titre de référence, voici ce que `release.yml` exécute à chaque push de tag `v*` :

--- a/docs/FR/RELEASE-PROCEDURE-FR.md
+++ b/docs/FR/RELEASE-PROCEDURE-FR.md
@@ -143,7 +143,12 @@ C'est le chemin recommandé parce qu'il rend l'oubli du gate
 structurellement impossible. Utilisez `scripts/release.sh vX.Y.Z
 --dry-run` pour vérifier que tous les gates passent au vert avant de
 tagger pour de vrai. Passez `--yes` pour sauter la confirmation
-interactive en contexte scripté.
+interactive en contexte scripté. Passez `--skip-lab` pour contourner
+explicitement le gate de validation lab (il émet un avertissement
+d'audit bien visible et n'écrit jamais le ledger), pour une release
+validée par d'autres moyens, par exemple un changement CLI ou docs
+seulement couvert par la suite E2E. Le flag ne saute que le gate lab,
+tous les autres pre-checks et le gate de version s'appliquent toujours.
 
 La prose ci-dessous reste la référence de ce que le script automatise,
 et le fallback quand un opérateur veut piloter les étapes à la main.

--- a/docs/RELEASE-PROCEDURE.md
+++ b/docs/RELEASE-PROCEDURE.md
@@ -206,15 +206,6 @@ git push origin chart-vA.B.C
 
 Either path triggers `.github/workflows/helm-release.yml`, which validates the chart tag against `Chart.yaml` via `scripts/check-helm-tag-version.sh`, packages the chart and pushes it to GHCR as an OCI artifact, cosign keyless signs it, attests SLSA build provenance and an SPDX SBOM (both queryable via `gh attestation verify`), and drafts the GitHub Release. Publish the drafted release once you have reviewed it.
 
-### 8. Public communication
-
-After the GitHub release page is generated and the chart is live:
-
-- LinkedIn post linking the release notes
-- Blog entry on the project site if the release introduces user-facing capabilities
-- Reddit, Hacker News, community channels when the change is broadly relevant
-- Institutional contacts (academic collaborators, customers under disclosure agreements) for releases that touch their use cases
-
 ## What the release workflow does
 
 For reference, here is what `release.yml` runs on every `v*` tag push:

--- a/docs/RELEASE-PROCEDURE.md
+++ b/docs/RELEASE-PROCEDURE.md
@@ -141,7 +141,12 @@ no dangling ref is left on the remote.
 This is the recommended path because it makes "forgetting the gate"
 structurally impossible. Use `scripts/release.sh vX.Y.Z --dry-run` to
 verify all gates green before tagging for real. Pass `--yes` to skip
-the interactive confirmation in scripted contexts.
+the interactive confirmation in scripted contexts. Pass `--skip-lab`
+to bypass the lab-validation gate explicitly (it logs a loud audit
+warning and never writes the ledger), for a release validated by other
+means such as a CLI or docs-only change covered by the E2E suite. The
+flag skips only the lab gate, every other pre-check and the version
+gate still apply.
 
 The prose below remains the reference of what the script automates,
 and the fallback when an operator wants to drive the steps by hand.

--- a/docs/ci-templates/github-actions-baseline.yml
+++ b/docs/ci-templates/github-actions-baseline.yml
@@ -41,7 +41,7 @@ jobs:
     name: Publish trunk baseline to gh-pages
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.8.3"
+      PERF_SENTINEL_VERSION: "0.8.4"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/github-actions.yml
+++ b/docs/ci-templates/github-actions.yml
@@ -63,7 +63,7 @@ jobs:
     name: Performance anti-pattern scan
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.8.3"
+      PERF_SENTINEL_VERSION: "0.8.4"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/gitlab-ci.yml
+++ b/docs/ci-templates/gitlab-ci.yml
@@ -23,7 +23,7 @@ stages:
   - perf-sentinel
 
 variables:
-  PERF_SENTINEL_VERSION: "0.8.3"
+  PERF_SENTINEL_VERSION: "0.8.4"
   PERF_SENTINEL_TRACES: "test-traces.json"
   PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/jenkinsfile.groovy
+++ b/docs/ci-templates/jenkinsfile.groovy
@@ -66,7 +66,7 @@ pipeline {
     }
 
     environment {
-        PERF_SENTINEL_VERSION = '0.8.3'
+        PERF_SENTINEL_VERSION = '0.8.4'
         PERF_SENTINEL_TRACES  = 'target/traces.json'
         PERF_SENTINEL_CONFIG  = '.perf-sentinel.toml'
     }

--- a/docs/schemas/examples/example-internal-G1.json
+++ b/docs/schemas/examples/example-internal-G1.json
@@ -203,7 +203,7 @@
   "integrity": {
     "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "binary_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.8.3",
+    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.8.4",
     "trace_integrity_chain": null,
     "signature": null
   },

--- a/docs/schemas/examples/example-official-public-G2.json
+++ b/docs/schemas/examples/example-official-public-G2.json
@@ -166,7 +166,7 @@
   "integrity": {
     "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "binary_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.8.3",
+    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.8.4",
     "trace_integrity_chain": null,
     "signature": null
   },

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,7 +2,10 @@
 # Constrained tag-and-push path for perf-sentinel: implements steps 5
 # and 6 of docs/RELEASE-PROCEDURE.md as a single fail-closed command.
 # Refuses to tag unless every pre-check and gate passes. The tag is
-# always signed (`git tag -s`), no bypass.
+# always signed (`git tag -s`), no bypass. The lab-validation gate is
+# the sole exception: --skip-lab skips it explicitly and logs a loud
+# audit warning, for releases validated by other means (e.g. a
+# CLI/docs-only change covered by the E2E suite).
 
 set -euo pipefail
 export LC_ALL=C
@@ -13,6 +16,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 VERSION=""
 DRY_RUN=0
 YES=0
+SKIP_LAB=0
 
 emit_error() {
   if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
@@ -32,16 +36,21 @@ emit_notice() {
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") vX.Y.Z [--dry-run] [--yes]
+Usage: $(basename "$0") vX.Y.Z [--dry-run] [--yes] [--skip-lab]
 
 Implements steps 5 (lab-validation gate) and 6 (signed tag + push) of
 docs/RELEASE-PROCEDURE.md. Fails closed: every pre-check and gate must
 pass before any tag is created or pushed. The tag is always signed,
-no bypass.
+no bypass. The lab gate is the sole skippable gate, via --skip-lab.
 
 Options:
   --dry-run   Run every gate, print the planned action, mutate nothing.
   --yes       Skip the interactive confirmation before tag and push.
+  --skip-lab  Bypass the lab-validation gate explicitly. Logs a loud
+              audit warning and never writes the ledger. For releases
+              validated by other means, e.g. a CLI/docs-only change
+              covered by the E2E suite. All other pre-checks and the
+              version gate still apply.
   -h, --help  Print this help and exit.
 
 Exit codes:
@@ -54,8 +63,9 @@ EOF
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -h|--help) usage; exit 0 ;;
-    --dry-run) DRY_RUN=1; shift ;;
-    --yes)     YES=1; shift ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    --yes)      YES=1; shift ;;
+    --skip-lab) SKIP_LAB=1; shift ;;
     --)        shift; break ;;
     -*)        emit_error "unknown option: $1"; usage >&2; exit 2 ;;
     *)
@@ -156,9 +166,14 @@ if ! "${REPO_ROOT}/scripts/check-tag-version.sh" "${VERSION}"; then
   exit 1
 fi
 
-# Gate: lab validation ledger has a fresh PASS for this version.
-if ! "${REPO_ROOT}/release-gate/check-lab-validation.sh" --version "${VERSION}"; then
-  emit_error "release-gate/check-lab-validation.sh refused ${VERSION}. Run the lab and append a PASS entry to release-gate/lab-validations.txt (step 4 of RELEASE-PROCEDURE.md)."
+# Gate: lab validation ledger has a fresh PASS for this version. The
+# operator can skip this single gate with --skip-lab, which logs a loud
+# audit warning instead of consulting the ledger. The ledger is never
+# written here, so a skipped lab leaves no false PASS behind.
+if [ "${SKIP_LAB}" -eq 1 ]; then
+  emit_notice "release: WARNING lab-validation gate bypassed by operator (--skip-lab). ${VERSION} was NOT validated in the simulation lab, and no PASS was recorded in the ledger."
+elif ! "${REPO_ROOT}/release-gate/check-lab-validation.sh" --version "${VERSION}"; then
+  emit_error "release-gate/check-lab-validation.sh refused ${VERSION}. Run the lab and append a PASS entry to release-gate/lab-validations.txt (step 4 of RELEASE-PROCEDURE.md), or pass --skip-lab to bypass this gate explicitly."
   exit 1
 fi
 
@@ -179,6 +194,9 @@ if [ "${YES}" -ne 1 ]; then
   if [ ! -t 0 ]; then
     emit_error "interactive confirmation requested but stdin is not a TTY. Pass --yes to confirm non-interactively."
     exit 1
+  fi
+  if [ "${SKIP_LAB}" -eq 1 ]; then
+    printf 'WARNING: lab-validation gate skipped (--skip-lab), %s was NOT lab-validated.\n' "${VERSION}"
   fi
   printf 'Tag %s at %s and push to origin?\n  Message: %s\nProceed? [y/N] ' "${VERSION}" "${SHORT_SHA}" "${TAG_MESSAGE}"
   read -r reply </dev/tty
@@ -213,7 +231,6 @@ fi
 emit_notice ""
 emit_notice "Released ${VERSION} at ${SHORT_SHA}"
 emit_notice "  .github/workflows/release.yml is now running."
-emit_notice "  Next manual steps (RELEASE-PROCEDURE.md):"
+emit_notice "  Next manual step (RELEASE-PROCEDURE.md):"
 emit_notice "    7. Release the Helm chart: scripts/release-chart.sh chart-vA.B.C (once the GHCR image lands)."
-emit_notice "    8. Public communication (LinkedIn, blog, etc.)."
 exit 0


### PR DESCRIPTION
## Summary

Release 0.8.4. Adds a `man` subcommand that renders the perf-sentinel manual page to stdout, and seeds every user-facing command's `--help` with copy-pasteable usage examples. Also tightens command help wording and adds an explicit `--skip-lab` bypass to the release tooling.

## Changes

- `perf-sentinel man` renders the top-level roff manual page to stdout via `clap_mangen`, mirroring the existing `completions` subcommand (lists the subcommands, like `git.1`).
- Usage-example blocks under `--help` of every user-facing command (`analyze`, `watch`, `explain`, `report`, `diff`, `tempo`, `jaeger-query`, `calibrate`, `pg-stat`, `query`, `ack`, `disclose`, `verify-hash`, `hash-bake`, `completions`), rendered under both `-h` and `--help`, mirroring the invocations documented in `docs/CLI.md` and the README.
- Tightened command help wording: removed semicolons in favor of separate sentences, and clarified that `disclose --intent audited` is reserved for a future release and exits with code 2.
- Documented the `man` subcommand in `docs/CLI.md`, its French mirror `docs/FR/CLI-FR.md`, and both READMEs.
- Release tooling: `--skip-lab` flag on `scripts/release.sh` to bypass the lab-validation gate explicitly (loud audit warning, ledger left untouched, all other pre-checks and the version gate still apply). Removed the public-communication step from `docs/RELEASE-PROCEDURE.md` and its French mirror.
- Internal: extracted the non-fatal `disclose` warnings into a helper to cut cognitive complexity (SonarCloud `rust:S3776`), and bumped Cargo dependencies to their latest patch versions.
- Version bump to 0.8.4, Helm chart to 0.2.49 in lockstep (appVersion 0.8.4).

## Checklist

Cargo:

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (plus `--features daemon` and `--no-default-features`)
- [x] `cargo fmt --all -- --check` passes
- [x] Default-features build AND `--no-default-features` build both pass when touching `daemon/`, `ingest/otlp.rs`, `ingest/tempo.rs`, `ingest/jaeger_query.rs` or any `#[cfg(feature = "...")]` code

Documentation and assets:

- [x] Public-facing docs updated (`README.md`, `README-FR.md`, relevant files under `docs/` and `docs/FR/`)
- [ ] Captures regenerated when CLI output, TUI, or HTML dashboard changed — n/a, no VHS tape renders `--help` or the `man` subcommand, nothing to regenerate
- [ ] `CHANGELOG.md` entry added under `[Unreleased]` — the root `CHANGELOG.md` is gitignored and maintained out-of-band by the maintainer; the tracked **chart** CHANGELOG (`charts/perf-sentinel/CHANGELOG.md`, section `[0.2.49]`) IS included

Versioning (release PRs only):

- [x] `workspace.package.version` bumped in root `Cargo.toml`
- [x] Intra-workspace `perf-sentinel-core = { version = "x.y.z", path = ... }` pin synced in `crates/sentinel-cli/Cargo.toml`
- [x] `PERF_SENTINEL_VERSION` synced in `docs/ci-templates/` and the snippets in `docs/CI.md` / `docs/FR/CI-FR.md`
- [x] `charts/perf-sentinel/Chart.yaml` (Helm chart) bumped in lockstep
- [x] `./scripts/check-tag-version.sh v0.8.4` passes locally

## Related issues

n/a
