### PR TITLE
Release 0.9.1: opentelemetry_sdk security patch (CVE-2026-48504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to perf-sentinel are documented in this file. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [0.9.1]
+
+### Security
+
+- Updated `opentelemetry_sdk` to 0.32.1, resolving CVE-2026-48504 (unbounded memory allocation in W3C Baggage propagation). This is a transitive dependency bump with no behavior or API change.
+
 ## [0.9.0]
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perf-sentinel"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "perf-sentinel-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sentinel-core", "crates/sentinel-cli"]
 resolver = "3"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "AGPL-3.0-only"
 rust-version = "1.96.0"

--- a/charts/perf-sentinel/CHANGELOG.md
+++ b/charts/perf-sentinel/CHANGELOG.md
@@ -6,6 +6,13 @@ From version 0.9.0 the chart `version` tracks the perf-sentinel
 application version. Both the chart `version` and `appVersion` move in
 lockstep, replacing the earlier independent `0.2.x` chart line.
 
+## [0.9.1]
+
+### Changed
+
+- `appVersion` bumped to `0.9.1`. The daemon binary updates `opentelemetry_sdk` to 0.32.1, resolving CVE-2026-48504 (unbounded memory allocation in W3C Baggage propagation). No chart template change, this bump tracks the new appVersion.
+- `artifacthub.io/images` annotation bumped to `ghcr.io/robintra/perf-sentinel:0.9.1` to keep the Artifact Hub display metadata in lockstep with `appVersion`.
+
 ## [0.9.0]
 
 ### Changed

--- a/charts/perf-sentinel/Chart.yaml
+++ b/charts/perf-sentinel/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   pool saturation, serialized parallelizable calls, fanout. Scores I/O
   intensity per endpoint (GreenOps).
 type: application
-version: 0.9.0
-appVersion: "0.9.0"
+version: 0.9.1
+appVersion: "0.9.1"
 kubeVersion: ">=1.24.0-0"
 home: https://github.com/robintra/perf-sentinel
 icon: https://raw.githubusercontent.com/robintra/perf-sentinel/main/logo/logo-horizontal.svg
@@ -85,7 +85,7 @@ annotations:
       description: "Chart 0.2.60: the chart now ships operator-facing alerting and disruption protection, both opt-in and off by default. An opt-in PrometheusRule (prometheusRule.enabled) packages the daemon's loss and saturation alerts (daemon unreachable via absent(perf_sentinel_active_traces), OTLP rejection, analysis shedding, analysis-queue saturation, findings store near cap, correlator-pair eviction, service-cardinality overflow, plus opt-in per-backend energy-scraper staleness under prometheusRule.energyScrapers), each alert naming the [daemon] knob to raise, with a prometheusRule.additionalRules passthrough for custom rules. An opt-in PodDisruptionBudget (podDisruptionBudget.enabled, default maxUnavailable 1 rather than minAvailable 1 so it does not wedge node drains on the single-replica daemon) adds voluntary-disruption protection. No application change, appVersion stays 0.8.12."
   artifacthub.io/images: |
     - name: perf-sentinel
-      image: ghcr.io/robintra/perf-sentinel:0.9.0
+      image: ghcr.io/robintra/perf-sentinel:0.9.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/perf-sentinel/Chart.yaml
+++ b/charts/perf-sentinel/Chart.yaml
@@ -37,6 +37,8 @@ annotations:
     - name: Helm deployment guide
       url: https://github.com/robintra/perf-sentinel/blob/main/docs/HELM-DEPLOYMENT.md
   artifacthub.io/changes: |
+    - kind: security
+      description: "appVersion 0.9.1: the daemon binary updates opentelemetry_sdk to 0.32.1, resolving CVE-2026-48504 (unbounded memory allocation in W3C Baggage propagation). No chart template change."
     - kind: changed
       description: "appVersion 0.9.0: the self-contained HTML dashboard is rebuilt as an application shell (sidebar navigation, Overview landing page, Findings master/detail with the Explain trace tree inline, severity-tinted KPI cards, syntax highlighting, embedded Geist fonts). The chart version is realigned to track appVersion (both 0.9.0), replacing the independent 0.2.x line. No chart template change."
     - kind: changed

--- a/crates/sentinel-cli/Cargo.toml
+++ b/crates/sentinel-cli/Cargo.toml
@@ -32,7 +32,7 @@ tempo = ["perf-sentinel-core/tempo"]
 jaeger-query = ["perf-sentinel-core/jaeger-query"]
 
 [dependencies]
-perf-sentinel-core = { version = "0.9.0", path = "../sentinel-core" }
+perf-sentinel-core = { version = "0.9.1", path = "../sentinel-core" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clap_complete = "4.6.5"
 clap_mangen = "0.3.0"

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -434,7 +434,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.9.0"
+      PERF_SENTINEL_VERSION: "0.9.1"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/FR/CI-FR.md
+++ b/docs/FR/CI-FR.md
@@ -486,7 +486,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.9.0"
+      PERF_SENTINEL_VERSION: "0.9.1"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/ci-templates/github-actions-baseline.yml
+++ b/docs/ci-templates/github-actions-baseline.yml
@@ -41,7 +41,7 @@ jobs:
     name: Publish trunk baseline to gh-pages
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.9.0"
+      PERF_SENTINEL_VERSION: "0.9.1"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/github-actions.yml
+++ b/docs/ci-templates/github-actions.yml
@@ -63,7 +63,7 @@ jobs:
     name: Performance anti-pattern scan
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.9.0"
+      PERF_SENTINEL_VERSION: "0.9.1"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/gitlab-ci.yml
+++ b/docs/ci-templates/gitlab-ci.yml
@@ -23,7 +23,7 @@ stages:
   - perf-sentinel
 
 variables:
-  PERF_SENTINEL_VERSION: "0.9.0"
+  PERF_SENTINEL_VERSION: "0.9.1"
   PERF_SENTINEL_TRACES: "test-traces.json"
   PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/jenkinsfile.groovy
+++ b/docs/ci-templates/jenkinsfile.groovy
@@ -66,7 +66,7 @@ pipeline {
     }
 
     environment {
-        PERF_SENTINEL_VERSION = '0.9.0'
+        PERF_SENTINEL_VERSION = '0.9.1'
         PERF_SENTINEL_TRACES  = 'target/traces.json'
         PERF_SENTINEL_CONFIG  = '.perf-sentinel.toml'
     }


### PR DESCRIPTION
## Summary

Bump the workspace and Helm chart to 0.9.1 to cut the release that ships the `opentelemetry_sdk` 0.32.1 update (already merged on main), resolving CVE-2026-48504. No behavior or API change.

## Changes

- Version bumped to 0.9.1 across the workspace, the intra-workspace pin, `Cargo.lock`, the CI snippets, and the root `CHANGELOG.md` (`Security`: `opentelemetry_sdk` 0.32.1, CVE-2026-48504).
- Helm chart bumped in lockstep: `version` and `appVersion` to 0.9.1 and the `artifacthub.io/images` tag to `:0.9.1`, with the chart `CHANGELOG` and `artifacthub.io/changes` entries documented.

## Checklist

Cargo:

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Default-features build AND `--no-default-features` build both pass

Documentation and assets:

- [x] Public-facing docs updated (chart `CHANGELOG` and `artifacthub.io/changes`, CI version snippets)
- [x] No CLI, TUI, or dashboard change, so no captures to regenerate
- [x] `CHANGELOG.md` entry added (under `[0.9.1]`, this is a release PR)

Versioning (release PRs only):

- [x] `workspace.package.version` bumped in root `Cargo.toml`
- [x] Intra-workspace `perf-sentinel-core` pin synced in `crates/sentinel-cli/Cargo.toml`
- [x] `PERF_SENTINEL_VERSION` synced in `docs/ci-templates/` and the snippets in `docs/CI.md` / `docs/FR/CI-FR.md`
- [x] `charts/perf-sentinel/Chart.yaml` bumped in lockstep
- [x] `./scripts/check-tag-version.sh v0.9.1` passes locally

## Related issues

Resolves CVE-2026-48504 in the published Docker image, which blocked the v0.9.0 image publish.
