### PR TITLE
docs(chart): correct the ingest-rejection alert scope in the 0.9.5 changelog

### DIFF
--- a/charts/perf-sentinel/CHANGELOG.md
+++ b/charts/perf-sentinel/CHANGELOG.md
@@ -10,14 +10,18 @@ lockstep, replacing the earlier independent `0.2.x` chart line.
 
 ### Added
 
-- New `PerfSentinelMemoryPressureRejecting` alert, and
-  `PerfSentinelIngestRejecting` is now scoped to `reason="channel_full"`,
-  so a memory-guard rejection carries the right remediation (raise
-  `resources.limits.memory`, not the ingest queue). Pairs with the new
-  daemon `[daemon] memory_high_water_pct` knob.
+- New `PerfSentinelMemoryPressureRejecting` alert in the opt-in
+  `PrometheusRule`, state-based on `perf_sentinel_ingest_memory_pressure == 1`,
+  so it keeps firing while the daemon holds ingest to protect RSS even
+  after exporters stop retrying. Its remediation points at
+  `resources.limits.memory` or more replicas, not the ingest queue. Pairs
+  with the new daemon `[daemon] memory_high_water_pct` knob.
 
 ### Changed
 
+- `PerfSentinelIngestRejecting` scoped to `reason!="memory_pressure"`, so it
+  still alerts on `channel_full`, `parse_error`, and `unsupported_media_type`
+  while memory-pressure rejections are owned by the new dedicated alert.
 - appVersion 0.9.5. The binary adds OTLP JSON auto-detection to batch
   `analyze --input` (single object or Collector `file` exporter NDJSON)
   and a new `mysql-stat` subcommand ranking MySQL hotspots from


### PR DESCRIPTION
## Summary

Corrects a factual error in the chart `## [0.9.5]` changelog entry. It described `PerfSentinelIngestRejecting` as scoped to `reason="channel_full"`, but the shipped template (`templates/prometheusrule.yaml`) scopes it to `reason!="memory_pressure"`, which keeps covering `channel_full`, `parse_error`, and `unsupported_media_type` while the new `PerfSentinelMemoryPressureRejecting` alert owns memory pressure. This matches the published `chart-v0.9.5` release notes.

## Changes

- Rewrite the `### Added` bullet to describe the new state-based memory-pressure alert accurately.
- Move the `PerfSentinelIngestRejecting` re-scope to `### Changed` with the correct `reason!="memory_pressure"` expression and the reasons it still covers.

Documentation only, no chart template or version change (the `charts/**` CHANGELOG-only exception in `check-chart-version-bumped.sh` applies).

## Related issues

n/a
