### PR TITLE
Mark code fragments in warnings and suggestions

### DIFF
--- a/crates/sentinel-cli/src/monitor.rs
+++ b/crates/sentinel-cli/src/monitor.rs
@@ -37,7 +37,7 @@ use sentinel_core::config::DaemonConfig;
 use sentinel_core::daemon::query_api::EnergyStatusResponse;
 use sentinel_core::report::{GreenSummary, Warning};
 use sentinel_core::score::carbon::IntensitySource;
-use sentinel_core::text_safety::sanitize_for_terminal;
+use sentinel_core::text_safety::{sanitize_for_terminal, strip_code_ticks};
 use tokio::sync::mpsc;
 
 // `Axis` aliased: ratatui's chart `Axis` is already in scope here.
@@ -842,7 +842,7 @@ fn build_advisor_lines(latest: Option<&Snapshot>) -> Vec<Line<'static>> {
                 warning_kind_style(&w.kind),
             ),
             Span::raw("] "),
-            Span::raw(sanitize_for_terminal(&w.message).into_owned()),
+            Span::raw(sanitize_for_terminal(&strip_code_ticks(&w.message)).into_owned()),
         ]));
     }
     if snapshot.warning_details.is_empty() {

--- a/crates/sentinel-cli/src/render.rs
+++ b/crates/sentinel-cli/src/render.rs
@@ -345,10 +345,13 @@ fn print_warnings(report: &Report, force_color: bool) {
     if !report.warning_details.is_empty() {
         println!("{bold}{yellow}Warnings:{reset}");
         for w in &report.warning_details {
+            // Backticks live in the data so the HTML can render code chips;
+            // a terminal shows them as literal noise.
+            let plain = strip_code_ticks(&w.message);
             println!(
                 "  [{}] {}",
                 sanitize_for_terminal(&w.kind),
-                sanitize_for_terminal(&w.message),
+                sanitize_for_terminal(&plain),
             );
         }
         println!();
@@ -1179,11 +1182,12 @@ fn write_diff_text(
         for w in &diff.warning_details {
             // Same guard as `print_warnings`: a baseline JSON is operator
             // input, and ack warnings carry user-authored signatures.
+            let plain = strip_code_ticks(&w.message);
             writeln!(
                 writer,
                 "  [{}] {}",
                 sanitize_for_terminal(&w.kind),
-                sanitize_for_terminal(&w.message)
+                sanitize_for_terminal(&plain)
             )?;
         }
         writeln!(writer)?;

--- a/crates/sentinel-core/src/detect/n_plus_one.rs
+++ b/crates/sentinel-core/src/detect/n_plus_one.rs
@@ -259,11 +259,11 @@ fn build_finding(
     };
     let suggestion = match event_type {
         EventType::Sql => format!(
-            "Use WHERE ... IN (?) to batch {} queries into one",
+            "Use `WHERE ... IN (?)` to batch {} queries into one",
             indices.len()
         ),
         EventType::HttpOut => format!(
-            "Use batch endpoint with ?ids=... to batch {} calls into one",
+            "Use a batch endpoint with `?ids=...` to batch {} calls into one",
             indices.len()
         ),
         EventType::Messaging => format!(

--- a/crates/sentinel-core/src/pipeline.rs
+++ b/crates/sentinel-core/src/pipeline.rs
@@ -176,10 +176,10 @@ fn daemon_only_green_backend_warning(
     Some(crate::report::Warning::new(
         crate::report::warnings::TUNING,
         format!(
-            "{} configured but this is a batch run: analyze starts no scraper, \
+            "{} configured but this is a batch run: `analyze` starts no scraper, \
              so neither measured energy nor real-time grid intensity reached the \
              score. Every carbon figure here is the I/O proxy estimate over \
-             embedded intensity data. Run perf-sentinel watch for measured figures.",
+             embedded intensity data. Run `perf-sentinel watch` for measured figures.",
             configured.join(", ")
         ),
     ))
@@ -519,28 +519,28 @@ mod tests {
         assert!(crate::config::load_from_str(toml).is_ok());
     }
 
-    /// Warnings render to the terminal, the TUI advisor, JSON and the HTML
-    /// banner. Backticks read as code in none of the first three, so no
-    /// producer uses them.
+    /// Backticks live in the data, like `suggested_fix.recommendation`:
+    /// the HTML renders them as code chips, the terminal and TUI strip them
+    /// with `strip_code_ticks`. A warning naming a command must mark it.
     #[test]
-    fn warning_messages_carry_no_markdown_ticks() {
+    fn warning_marks_its_command_as_code() {
         let config = crate::config::load_from_str(
-            "[thresholds]\nmin_usable_span_ratio = 0.8\n\n\
-             [green]\nenabled = true\n\n\
+            "[green]\nenabled = true\n\n\
              [green.scaphandre]\nendpoint = \"http://127.0.0.1:8080/metrics\"\n",
         )
         .unwrap();
 
-        let report = analyze(vec![], &config);
+        let message = &analyze(vec![], &config).warning_details[0].message;
 
-        assert!(!report.warning_details.is_empty());
-        for warning in &report.warning_details {
-            assert!(
-                !warning.message.contains('`'),
-                "warning carries a backtick: {}",
-                warning.message
-            );
-        }
+        assert!(message.contains("`analyze`"), "{message}");
+        assert!(message.contains("`perf-sentinel watch`"), "{message}");
+        assert_eq!(
+            crate::text_safety::strip_code_ticks(message)
+                .matches('`')
+                .count(),
+            0,
+            "the terminal path must render it tick-free"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two prose surfaces carried code fragments that rendered as plain text: the report-warnings banner showed literal backticks, and the generic suggestion never marked its code at all. Both now follow the project's existing pattern — backticks live in the data, the HTML renders them as code chips, the terminal and TUI strip them.

## Changes

- `daemon_only_green_backend_warning` marks `analyze` and `perf-sentinel watch` as code, matching how `suggested_fix.recommendation` has carried backticks since 0.9.x.
- The N+1 SQL and N+1 HTTP suggestions mark their code: `` `WHERE ... IN (?)` `` and `` `?ids=...` ``. The HTML already fed `suggestion` through `proseInto`, so the chips appear with no template change.
- The report-warnings banner renders through `proseInto` like every other prose surface, instead of a flat text node.
- The terminal report, the terminal `diff` block and the monitor TUI advisor strip ticks from warning messages with `strip_code_ticks`, the same guard those surfaces already apply to `suggested_fix`.
- A test pins the contract: the warning marks its command, and `strip_code_ticks` leaves the terminal path tick-free.

## Checklist

Cargo:

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes — 3061 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Default-features build AND `--no-default-features` build both pass when touching `daemon/`, `ingest/otlp/`, `ingest/tempo.rs`, `ingest/jaeger_query.rs` or any `#[cfg(feature = "...")]` code

Documentation and assets:

- [x] Public-facing docs updated (`README.md`, `README-FR.md`, relevant files under `docs/` and `docs/FR/`) — n/a, no user-facing behaviour or option changed
- [ ] Captures regenerated when CLI output, TUI, or HTML dashboard changed — not done, same note as #111
- [x] `CHANGELOG.md` entry added under the upcoming version section — n/a, wording refinement of an entry already in `[0.11.0]`

Versioning (release PRs only):

- [x] n/a, not a release PR

## Related issues

Follow-up to #111. Reported while reviewing the rendered dashboard: the banner showed literal backticks, and `WHERE … IN (?)` was not marked as code.
