### PR TITLE
Use generic tenant and namespace names in fixtures

### DIFF
--- a/crates/sentinel-cli/src/render.rs
+++ b/crates/sentinel-cli/src/render.rs
@@ -1728,11 +1728,11 @@ mod tests {
         prod.grouping = vec![
             GroupingAttribute {
                 key: "tenant.id".into(),
-                value: "byec".into(),
+                value: "acme".into(),
             },
             GroupingAttribute {
                 key: "k8s.namespace.name".into(),
-                value: "multitenant-2".into(),
+                value: "shared-cluster".into(),
             },
         ];
         let plain = sample_finding();
@@ -1746,7 +1746,7 @@ mod tests {
         assert_eq!(out.matches("tenant.id:").count(), 1, "{out}");
         assert_eq!(out.matches("k8s.namespace.name:").count(), 1, "{out}");
         assert!(
-            out.contains("byec") && out.contains("multitenant-2"),
+            out.contains("acme") && out.contains("shared-cluster"),
             "{out}"
         );
     }

--- a/crates/sentinel-cli/tests/browser/tests/dashboard.spec.ts
+++ b/crates/sentinel-cli/tests/browser/tests/dashboard.spec.ts
@@ -718,7 +718,7 @@ test("36. the ack modal names every grouping the acknowledgment will cover", asy
         // the expected count deterministic.
         payload.report.findings.forEach((f: Record<string, any>, i: number) => {
           f.signature = "shared-sig";
-          f.grouping = [{ key: "tenant.id", value: i % 2 === 0 ? "byec" : "cogep" }];
+          f.grouping = [{ key: "tenant.id", value: i % 2 === 0 ? "acme" : "globex" }];
         });
         return open + JSON.stringify(payload) + close;
       },
@@ -735,8 +735,8 @@ test("36. the ack modal names every grouping the acknowledgment will cover", asy
   await expect(scope).toBeVisible();
   await expect(scope).toContainText("2 groupings");
   await expect(scope).toContainText("tenant.id");
-  await expect(scope).toContainText("byec");
-  await expect(scope).toContainText("cogep");
+  await expect(scope).toContainText("acme");
+  await expect(scope).toContainText("globex");
 });
 
 test("37. report warnings render in a banner that survives a tab switch", async ({ page }) => {
@@ -819,7 +819,7 @@ test("39. the ack modal warns when a signature spans grouped and ungrouped rows"
         const payload = JSON.parse(json);
         payload.report.findings.forEach((f: Record<string, any>, i: number) => {
           f.signature = "shared-sig";
-          f.grouping = i % 2 === 0 ? [{ key: "tenant.id", value: "byec" }] : [];
+          f.grouping = i % 2 === 0 ? [{ key: "tenant.id", value: "acme" }] : [];
         });
         return open + JSON.stringify(payload) + close;
       },

--- a/crates/sentinel-core/src/detect/n_plus_one.rs
+++ b/crates/sentinel-core/src/detect/n_plus_one.rs
@@ -388,11 +388,11 @@ mod tests {
             event.grouping = vec![
                 crate::event::GroupingAttribute {
                     key: Arc::from("tenant.id"),
-                    value: Arc::from("byec"),
+                    value: Arc::from("acme"),
                 },
                 crate::event::GroupingAttribute {
                     key: Arc::from("k8s.namespace.name"),
-                    value: Arc::from("multitenant-2"),
+                    value: Arc::from("shared-cluster"),
                 },
             ];
         }
@@ -400,7 +400,7 @@ mod tests {
 
         let findings = detect_n_plus_one(&trace, 5, 500, SanitizerAwareMode::default());
 
-        assert_eq!(findings[0].grouping_value(), Some("byec"));
+        assert_eq!(findings[0].grouping_value(), Some("acme"));
         assert_eq!(
             findings[0].grouping.len(),
             2,

--- a/crates/sentinel-core/src/event.rs
+++ b/crates/sentinel-core/src/event.rs
@@ -309,7 +309,7 @@ impl CodeLocation {
 }
 
 /// One attribute captured for grouping, with the attribute name it came
-/// from so an operator can tell `tenant.id=byec` from `k8s.namespace.name=byec`.
+/// from so an operator can tell `tenant.id=acme` from `k8s.namespace.name=acme`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GroupingAttribute {
     pub key: Arc<str>,
@@ -607,12 +607,12 @@ mod tests {
     fn serde_roundtrip_with_grouping() {
         let mut value: serde_json::Value = serde_json::from_str(sample_sql_json()).unwrap();
         value["grouping"] = serde_json::json!([
-            {"key": "tenant.id", "value": "byec"},
-            {"key": "k8s.namespace.name", "value": "multitenant-2"},
+            {"key": "tenant.id", "value": "acme"},
+            {"key": "k8s.namespace.name", "value": "shared-cluster"},
         ]);
 
         let event: SpanEvent = serde_json::from_value(value).unwrap();
-        assert_eq!(event.grouping_value(), Some("byec"));
+        assert_eq!(event.grouping_value(), Some("acme"));
         assert_eq!(event.grouping.len(), 2);
 
         let serialized = serde_json::to_string(&event).unwrap();

--- a/crates/sentinel-core/src/ingest/json.rs
+++ b/crates/sentinel-core/src/ingest/json.rs
@@ -559,7 +559,7 @@ mod tests {
             },
             crate::event::GroupingAttribute {
                 key: "tenant.id".into(),
-                value: "byec".into(),
+                value: "acme".into(),
             },
             crate::event::GroupingAttribute {
                 key: "k8s.namespace.name".into(),
@@ -579,7 +579,7 @@ mod tests {
             .collect();
         assert_eq!(
             captured,
-            vec![("tenant.id", "byec"), ("k8s.namespace.name", "prod-eu")]
+            vec![("tenant.id", "acme"), ("k8s.namespace.name", "prod-eu")]
         );
 
         let disabled = JsonIngest::new(1_048_576)
@@ -1234,7 +1234,7 @@ mod tests {
         let mut attrs: Vec<String> = (0..crate::config::MAX_GROUPING_ATTRIBUTES + 2)
             .map(|i| format!(r#"{{"key":"filler.{i}","value":"v{i}"}}"#))
             .collect();
-        attrs.push(r#"{"key":"tenant.id","value":"byec"}"#.to_string());
+        attrs.push(r#"{"key":"tenant.id","value":"acme"}"#.to_string());
         let raw = format!(
             r#"[{{"timestamp":"2025-07-10T14:32:01.123Z","trace_id":"t1","span_id":"s1",
                  "service":"svc","type":"sql","operation":"SELECT",
@@ -1251,7 +1251,7 @@ mod tests {
 
         assert_eq!(
             events[0].grouping_value(),
-            Some("byec"),
+            Some("acme"),
             "{:?}",
             events[0].grouping
         );

--- a/crates/sentinel-core/src/ingest/otlp/tests.rs
+++ b/crates/sentinel-core/src/ingest/otlp/tests.rs
@@ -1710,20 +1710,20 @@ fn grouping_is_extracted_from_resource_attributes() {
 #[test]
 fn grouping_falls_back_to_span_attributes() {
     let mut span = make_sql_span(&[1; 16], &[2; 8], &[], "SELECT 1", 0, 1_000_000);
-    span.attributes.push(make_kv("tenant.id", "byec"));
+    span.attributes.push(make_kv("tenant.id", "acme"));
     let mut req = make_request("order-svc", vec![span]);
     req.resource_spans[0]
         .resource
         .as_mut()
         .unwrap()
         .attributes
-        .push(make_kv("k8s.namespace.name", "multitenant-2"));
+        .push(make_kv("k8s.namespace.name", "shared-cluster"));
 
     let keys: Vec<Arc<str>> = vec![Arc::from("tenant.id"), Arc::from("k8s.namespace.name")];
     let (events, _) = convert_otlp_request_counted_with_grouping(&req, Some(&keys));
 
-    assert_eq!(events[0].grouping_value(), Some("byec"));
-    assert_eq!(events[0].grouping[1].value.as_ref(), "multitenant-2");
+    assert_eq!(events[0].grouping_value(), Some("acme"));
+    assert_eq!(events[0].grouping[1].value.as_ref(), "shared-cluster");
 }
 
 // ----- cloud.region sanitization at OTLP boundary -----

--- a/crates/sentinel-core/src/ingest/tempo.rs
+++ b/crates/sentinel-core/src/ingest/tempo.rs
@@ -1257,7 +1257,7 @@ mod tests {
             attributes: vec![
                 kv("db.system", "postgresql"),
                 kv("db.statement", "SELECT * FROM orders WHERE id = 1"),
-                kv("tenant.id", "byec"),
+                kv("tenant.id", "acme"),
             ],
             ..Default::default()
         };
@@ -1291,7 +1291,7 @@ mod tests {
             1,
             "configuring grouping must not change which spans convert"
         );
-        assert_eq!(grouped[0].grouping_value(), Some("byec"));
+        assert_eq!(grouped[0].grouping_value(), Some("acme"));
     }
 
     /// Mirrors the real lab trace that cost a validation round: a single

--- a/crates/sentinel-core/src/report/html/html_template.html
+++ b/crates/sentinel-core/src/report/html/html_template.html
@@ -1410,7 +1410,7 @@
     return g ? g.value : "";
   }
   // Label for the grouping chips and rows: the attribute that decided the
-  // identity, so `tenant.id=byec` never reads as a namespace.
+  // identity, so `tenant.id=acme` never reads as a namespace.
   function findingGroupingKey(f) {
     var g = findingGrouping(f);
     return g ? g.key : "";


### PR DESCRIPTION
## Summary

The 0.11.0 grouping fixtures used tenant and namespace names taken from a real production cluster. They carry no secret, but they name a third party in a public repository and they read as if the project shipped with someone's deployment baked in. Replaced with the conventional placeholder names.

## Changes

- `byec` becomes `acme`, `cogep` becomes `globex`, `multitenant-2` becomes `shared-cluster`, across the eight files that carried them: `event.rs`, `ingest/json.rs`, `ingest/otlp/tests.rs`, `ingest/tempo.rs`, `detect/n_plus_one.rs`, `render.rs`, `html_template.html` and the Playwright suite.
- No behaviour change: every occurrence is a test fixture value or a doc-comment example. The grouping assertions keep their shape, only the literals move.

## Checklist

Cargo:

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes — 3061 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Default-features build AND `--no-default-features` build both pass when touching `daemon/`, `ingest/otlp/`, `ingest/tempo.rs`, `ingest/jaeger_query.rs` or any `#[cfg(feature = "...")]` code
- [x] Playwright suite passes — 41 passed, 1 skipped

Documentation and assets:

- [x] Public-facing docs updated — n/a, no user-facing behaviour or option changed
- [x] Captures regenerated when CLI output, TUI, or HTML dashboard changed — n/a, no rendered surface changed
- [x] `CHANGELOG.md` entry added — n/a, fixture rename with no user-visible effect

Versioning (release PRs only):

- [x] n/a, not a release PR

## Related issues

Follow-up to #111, where these names entered the tree.
