### PR TITLE
Render the warning kind as a label, not a code chip

### DIFF
--- a/crates/sentinel-cli/tests/browser/tests/dashboard.spec.ts
+++ b/crates/sentinel-cli/tests/browser/tests/dashboard.spec.ts
@@ -765,7 +765,8 @@ test("37. report warnings render in a banner that survives a tab switch", async 
   await page.waitForSelector("[role=tablist]");
 
   const banner = page.locator("#report-warnings");
-  await expect(banner).toContainText("[tuning] [green.alumet] configured");
+  await expect(banner).toContainText("tuning");
+  await expect(banner).toContainText("[green.alumet] configured");
 
   // The whole point of placing it outside the panels.
   await page.keyboard.press("g");

--- a/crates/sentinel-core/src/report/html/html_template.html
+++ b/crates/sentinel-core/src/report/html/html_template.html
@@ -423,6 +423,9 @@
   /* -------- banner / empty / drill -------- */
   .ps-banner { background: var(--info-bg); border: 0; border-radius: 10px; padding: 8px 12px; font-size: 11.5px; color: var(--info-fg); }
   .ps-report-warnings { background: var(--warn-bg); color: var(--warn-fg); margin-bottom: 14px; }
+  /* The warning kind is a label, not something the operator types: it must
+     not read as a code chip sitting next to a real config section. */
+  .ps-warn-kind { font-family: var(--font-ui); font-size: 9.5px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; opacity: 0.45; margin-right: 9px; }
   .ps-empty { padding: 30px; text-align: center; color: var(--text-2); font-size: 13px; background: var(--surface); border: 1px solid transparent; border-radius: var(--r); }
   .ps-drill { background: var(--info-bg); border: 0; border-radius: 10px; padding: 10px 12px; font-size: 11.5px; color: var(--info-fg); }
   .ps-drill-label { font-size: 11.5px; color: var(--info-fg); margin-bottom: 4px; opacity: .8; }
@@ -4582,17 +4585,18 @@
   // needs a different action from the reader.
   function renderReportWarnings() {
     var details = report.warning_details || [];
-    var lines = details.length
-      ? details.map(function (w) { return "[" + w.kind + "] " + w.message; })
-      : (report.warnings || []);
-    if (!lines.length) return;
+    var rows = details.length
+      ? details.map(function (w) { return { kind: w.kind, message: w.message }; })
+      : (report.warnings || []).map(function (m) { return { kind: null, message: m }; });
+    if (!rows.length) return;
     var b = document.getElementById("report-warnings");
     b.style.display = "";
-    lines.forEach(function (line) {
+    rows.forEach(function (w) {
+      var row = el("div", null, null);
+      if (w.kind) row.appendChild(el("span", "ps-warn-kind", w.kind));
       // Through `proseInto` like every other prose surface: a warning names
       // config keys and commands, and they must read as code here too.
-      var row = el("div", null, null);
-      proseInto(row, line);
+      proseInto(row, w.message);
       b.appendChild(row);
     });
   }


### PR DESCRIPTION
## Summary

The warnings banner printed the warning kind as plain prose (`[tuning] ...`) right next to a real config section rendered as a code chip. Marking the kind as code too would have been worse: it would claim `[tuning]` is something the operator can find in a file, which it is not. The kind is a category perf-sentinel assigns, so it now renders as a label.

## Changes

- `renderReportWarnings` emits the kind as a `.ps-warn-kind` span and passes only the message through `proseInto`, instead of splicing `[kind]` into the prose string.
- `.ps-warn-kind`: uppercase, letter-spaced, muted. It recedes behind the message, since the banner's warn background already signals severity and the category is the least actionable part of the line.
- The plain `report.warnings` fallback keeps working, it just carries no kind.

Terminal output is unchanged: `print_warnings` keeps `[tuning]` in brackets, having no typography to separate a label from code.

## Checklist

Cargo:

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes — 3061 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Default-features build AND `--no-default-features` build both pass when touching `daemon/`, `ingest/otlp/`, `ingest/tempo.rs`, `ingest/jaeger_query.rs` or any `#[cfg(feature = "...")]` code
- [x] Playwright suite passes — 41 passed, 1 skipped

Documentation and assets:

- [x] Public-facing docs updated — n/a, no user-facing behaviour or option changed
- [ ] Captures regenerated when CLI output, TUI, or HTML dashboard changed — not done, same note as #111, #112 and #114
- [x] `CHANGELOG.md` entry added — n/a, presentation refinement of an entry already in `[0.11.0]`

Versioning (release PRs only):

- [x] n/a, not a release PR

## Related issues

Follow-up to #114. The banner test pinned `[tuning] [green.alumet] configured` as one string and now asserts the label and the code chip separately.
