### PR TITLE
Strip code ticks from the suggestion on every text surface

### DIFF
--- a/crates/sentinel-cli/src/render.rs
+++ b/crates/sentinel-cli/src/render.rs
@@ -711,7 +711,7 @@ fn print_finding_entry(index: usize, finding: &sentinel_core::detect::Finding, c
     );
     println!(
         "    {cyan}Suggestion:{reset} {}",
-        sanitize_for_terminal(&finding.suggestion)
+        sanitize_for_terminal(&strip_code_ticks(&finding.suggestion))
     );
     if !finding.confidence.is_batch() {
         println!(
@@ -1309,7 +1309,7 @@ fn write_finding_block(
         writer,
         "      {cyan}{:<12}{reset} {}",
         "Suggestion:",
-        sanitize_for_terminal(&f.suggestion)
+        sanitize_for_terminal(&strip_code_ticks(&f.suggestion))
     )?;
     if let Some(ref fix) = f.suggested_fix {
         let label = format!("Fix [{}]:", sanitize_for_terminal(&fix.framework));
@@ -1967,6 +1967,17 @@ mod tests {
             !out.as_bytes().contains(&0x07),
             "BEL terminator leaked, got:\n{out}"
         );
+    }
+
+    /// The suggestion carries backticks so the HTML can chip them. Every
+    /// terminal surface must strip them, exactly like `suggested_fix`.
+    #[test]
+    fn backticks_in_suggestion_never_reach_the_terminal() {
+        let mut f = sample_finding();
+        f.suggestion = "Use `WHERE ... IN (?)` to batch 5 queries into one".to_string();
+        let out = render_text(&diff_with_new(vec![f]));
+        assert!(!out.contains('`'), "backtick leaked, got:\n{out}");
+        assert!(out.contains("WHERE ... IN (?)"), "got:\n{out}");
     }
 
     #[test]

--- a/crates/sentinel-cli/src/tui/mod.rs
+++ b/crates/sentinel-cli/src/tui/mod.rs
@@ -2564,7 +2564,7 @@ fn draw_detail_panel(f: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("Suggestion: ", Style::default().fg(Color::Cyan)),
-            Span::raw(&finding.suggestion),
+            Span::raw(strip_code_ticks(&finding.suggestion).into_owned()),
         ]),
     ];
 

--- a/crates/sentinel-core/src/explain.rs
+++ b/crates/sentinel-core/src/explain.rs
@@ -323,7 +323,7 @@ fn write_finding_details(out: &mut String, prefix: &str, f: &InlineFinding, c: &
     let mut lines: Vec<String> = Vec::with_capacity(3);
     lines.push(format!(
         "suggestion: {}",
-        sanitize_for_terminal(&f.suggestion)
+        sanitize_for_terminal(&crate::text_safety::strip_code_ticks(&f.suggestion))
     ));
     if let Some(ref fix) = f.suggested_fix {
         let url_part = match fix.reference_url.as_deref().and_then(safe_url) {

--- a/crates/sentinel-core/src/report/sarif.rs
+++ b/crates/sentinel-core/src/report/sarif.rs
@@ -252,7 +252,8 @@ fn finding_to_result(finding: &Finding) -> SarifResult {
     let safe_service = strip_bidi_and_invisible(&finding.service);
     let safe_endpoint = strip_bidi_and_invisible(&finding.source_endpoint);
     let safe_template = strip_bidi_and_invisible(&finding.pattern.template);
-    let safe_suggestion = strip_bidi_and_invisible(&finding.suggestion);
+    let plain_suggestion = strip_code_ticks(&finding.suggestion);
+    let safe_suggestion = strip_bidi_and_invisible(&plain_suggestion);
 
     let message = format!(
         "{} in {} on {}: {} ({} occurrences, {}ms window). {}",


### PR DESCRIPTION
## Summary

Backticks added to the generic `suggestion` in #112 leaked as literal characters into every plain-text surface. `perf-sentinel analyze` printed ``Use `WHERE ... IN (?)` to batch 10 queries into one``. The tick-stripping added in #112 covered `suggested_fix.recommendation` and warning messages, but `Finding.suggestion` was never routed through it.

Found by diffing this branch's CLI output against the v0.10.0 binary while checking which `docs/img` captures the 0.11.0 changes actually affect.

## Changes

Five surfaces now apply `strip_code_ticks` to `Finding.suggestion`, matching what each already did for `suggested_fix`:

- `render.rs` — the report `Suggestion:` line and the `diff` block
- `tui/mod.rs` — the finding detail panel
- `explain.rs` — the `suggestion:` node in the trace tree
- `sarif.rs` — the result message

The HTML dashboard is unchanged: it already fed `suggestion` through `proseInto`, which is why the chips rendered correctly there and the leak was invisible in the dashboard.

A test pins the contract: a suggestion carrying backticks renders with none, and keeps its text.

## Checklist

Cargo:

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes — 3062 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Default-features build AND `--no-default-features` build both pass when touching `daemon/`, `ingest/otlp/`, `ingest/tempo.rs`, `ingest/jaeger_query.rs` or any `#[cfg(feature = "...")]` code

Documentation and assets:

- [x] Public-facing docs updated — n/a, no user-facing option changed
- [ ] Captures regenerated when CLI output, TUI, or HTML dashboard changed — in progress on a follow-up, deliberately after this fix so the captures do not freeze the bug
- [x] `CHANGELOG.md` entry added — n/a, this repairs an entry already in `[0.11.0]`

Versioning (release PRs only):

- [x] n/a, not a release PR

## Related issues

Fixes a regression from #112.
