### PR TITLE
release: 0.22.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,15 @@ jobs:
       - name: Audit dependencies
         run: cargo audit
 
+      # Without a version, SonarCloud keeps the last one it ever saw and the
+      # "previous version" new-code period stops moving: on 2026-09-11 it still
+      # reached back to March, so a newly activated rule reddened the gate over
+      # six months of untouched code.
+      - name: Read the workspace version
+        id: workspace_version
+        run: |
+          echo "value=$(awk -F'"' '/^version = / {print $2; exit}' Cargo.toml)" >> "$GITHUB_OUTPUT"
+
       - name: SonarCloud Scan
         if: env.SONAR_TOKEN != ''
         # The 40-hex value below is the action's git SHA pin (Dependabot-managed),
@@ -191,6 +200,8 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: -Dsonar.projectVersion=${{ steps.workspace_version.outputs.value }}
 
   # Smoke-test the musl release target so glibc/musl regressions (new C-FFI
   # crate, ring toolchain break, missing musl-tools) surface on PRs instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to perf-sentinel are documented in this file. Format loosely
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-09-11
+
 ### Fixed
 
 - Nine blocking file operations ran on runtime workers inside `async` functions. The two archive writers, for analysis windows and for incidents, move to `tokio::task::spawn_blocking` and read their channel with `blocking_recv`, which keeps the synchronous buffered I/O those writers deliberately use and stops it from parking a worker that holds other tasks. Their bodies are unchanged, so the chain hashing, the rotation and the recovery after a partial write behave exactly as before. The remaining seven are one-shot setup and teardown calls, in the JSON socket listener, the daemon shutdown path and `capture finish`, and move to `tokio::fs`. No behaviour changes anywhere, and no configuration, route or metric moves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to perf-sentinel are documented in this file. Format loosely
 
 ## [Unreleased]
 
+### Fixed
+
+- Nine blocking file operations ran on runtime workers inside `async` functions. The two archive writers, for analysis windows and for incidents, move to `tokio::task::spawn_blocking` and read their channel with `blocking_recv`, which keeps the synchronous buffered I/O those writers deliberately use and stops it from parking a worker that holds other tasks. Their bodies are unchanged, so the chain hashing, the rotation and the recovery after a partial write behave exactly as before. The remaining seven are one-shot setup and teardown calls, in the JSON socket listener, the daemon shutdown path and `capture finish`, and move to `tokio::fs`. No behaviour changes anywhere, and no configuration, route or metric moves.
+
 ## [0.22.0] - 2026-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to perf-sentinel are documented in this file. Format loosely
 ### Fixed
 
 - Nine blocking file operations ran on runtime workers inside `async` functions. The two archive writers, for analysis windows and for incidents, move to `tokio::task::spawn_blocking` and read their channel with `blocking_recv`, which keeps the synchronous buffered I/O those writers deliberately use and stops it from parking a worker that holds other tasks. Their bodies are unchanged, so the chain hashing, the rotation and the recovery after a partial write behave exactly as before. The remaining seven are one-shot setup and teardown calls, in the JSON socket listener, the daemon shutdown path and `capture finish`, and move to `tokio::fs`. No behaviour changes anywhere, and no configuration, route or metric moves.
+- The SonarCloud scan now passes `sonar.projectVersion`. Without it the service kept the last version it had ever seen, so the "previous version" new-code period stopped moving and reached back six months, which is how a newly activated rule came to redden the quality gate over untouched code.
 
 ## [0.22.0] - 2026-09-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perf-sentinel"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "perf-sentinel-core"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/sentinel-core", "crates/sentinel-cli"]
 resolver = "3"
 
 [workspace.package]
-version = "0.22.0"
+version = "0.22.1"
 edition = "2024"
 license = "AGPL-3.0-only"
 rust-version = "1.98.1"

--- a/charts/perf-sentinel/CHANGELOG.md
+++ b/charts/perf-sentinel/CHANGELOG.md
@@ -10,6 +10,22 @@ both, while a chart-only release bumps `version` alone and leaves
 through `0.9.21` and `0.9.27` did. Read `appVersion` in `Chart.yaml`, never
 the chart version, to know which daemon image ships.
 
+## [0.22.1]
+
+### Changed
+
+- **`appVersion` moves to `0.22.1`.** The daemon no longer runs blocking file
+  operations on its runtime workers. The two archive writers, for analysis
+  windows and for incidents, move to a blocking thread and keep the synchronous
+  buffered I/O they deliberately use, so a slow or stalled disk parks a thread
+  dedicated to writing instead of a worker that polls every other task. The
+  seven remaining calls are one-shot setup and teardown and use the async file
+  API. Nothing observable changes: the archive chain hashing, the rotation and
+  the recovery after a partial write are byte-identical.
+
+No `values.yaml` key is added or removed, no template changes, and the shipped
+alerts are unchanged.
+
 ## [0.22.0]
 
 ### Changed

--- a/charts/perf-sentinel/Chart.yaml
+++ b/charts/perf-sentinel/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   pool saturation, serialized parallelizable calls, fanout. Scores I/O
   intensity per endpoint (GreenOps).
 type: application
-version: 0.22.0
-appVersion: "0.22.0"
+version: 0.22.1
+appVersion: "0.22.1"
 kubeVersion: ">=1.24.0-0"
 home: https://github.com/robintra/perf-sentinel
 icon: https://raw.githubusercontent.com/robintra/perf-sentinel/main/logo/logo-horizontal.svg
@@ -36,11 +36,11 @@ annotations:
     - name: Helm deployment guide
       url: https://github.com/robintra/perf-sentinel/blob/main/docs/HELM-DEPLOYMENT.md
   artifacthub.io/changes: |
-    - kind: added
-      description: "appVersion 0.22.0. Every key-gated route accepts `Authorization: Bearer <key>` beside `X-API-Key`, either one, the same key and the same constant-time comparison. It matters to operators because neither Kubernetes operator that generates an Alertmanager receiver can send an arbitrary header, so `X-API-Key` was out of reach from a generated receiver: `AlertmanagerConfig` has no field for one, and `VMAlertmanagerConfig` declares its `http_config` as an open object where the operator renders only the fields it knows. Both carry a bearer token. Ready-made alert rules and receivers for both operators now ship under `examples/`, carrying the `service`, `perf_sentinel_kind` and `namespace` labels `POST /api/incidents` reads, with the fleet-wide service derivation they need. No values.yaml key is added or removed, no template changes, no shipped alert changes."
+    - kind: fixed
+      description: "appVersion 0.22.1. Nine blocking file operations that ran on runtime workers inside async functions are fixed. The two archive writers, for analysis windows and for incidents, move to a blocking thread and keep the synchronous buffered I/O they deliberately use, so a slow disk no longer parks a worker that polls other tasks. The remaining seven are one-shot setup and teardown calls in the JSON socket listener, the shutdown path and capture finish, and use the async file API. No behaviour changes, the chain hashing and the rotation are byte-identical. No values.yaml key is added or removed, no template changes, no shipped alert changes."
   artifacthub.io/images: |
     - name: perf-sentinel
-      image: ghcr.io/robintra/perf-sentinel:0.22.0
+      image: ghcr.io/robintra/perf-sentinel:0.22.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/crates/sentinel-cli/Cargo.toml
+++ b/crates/sentinel-cli/Cargo.toml
@@ -32,7 +32,7 @@ tempo = ["perf-sentinel-core/tempo"]
 jaeger-query = ["perf-sentinel-core/jaeger-query"]
 
 [dependencies]
-perf-sentinel-core = { version = "0.22.0", path = "../sentinel-core" }
+perf-sentinel-core = { version = "0.22.1", path = "../sentinel-core" }
 clap = { version = "4.6.6", features = ["derive", "env"] }
 clap_complete = "4.6.9"
 clap_mangen = "0.3.3"

--- a/crates/sentinel-core/src/capture.rs
+++ b/crates/sentinel-core/src/capture.rs
@@ -472,7 +472,8 @@ impl Capture {
         // inode, so every count above is real while the path holds nothing.
         // Reporting success there would send the next step to a file that
         // was never going to be readable.
-        let output_matches = std::fs::metadata(&self.output)
+        let output_matches = tokio::fs::metadata(&self.output)
+            .await
             .is_ok_and(|metadata| output_identity(&metadata) == self.output_identity);
         if !output_matches {
             return Err(CaptureError::Output {

--- a/crates/sentinel-core/src/daemon/archive.rs
+++ b/crates/sentinel-core/src/daemon/archive.rs
@@ -93,8 +93,16 @@ pub fn spawn(
     let cap_bytes = cfg.max_size_mb.saturating_mul(1_048_576);
     let max_files = cfg.max_files;
     let (tx, rx) = mpsc::channel::<OwnedArchive>(CHANNEL_CAPACITY);
-    let join = tokio::spawn(async move {
-        run_writer(rx, path, file, bytes_written, cap_bytes, max_files, metrics).await;
+    let join = tokio::task::spawn_blocking(move || {
+        run_writer(
+            rx,
+            &path,
+            file,
+            bytes_written,
+            cap_bytes,
+            max_files,
+            &metrics,
+        );
     });
     Ok(ArchiveHandle { tx, join })
 }
@@ -230,22 +238,25 @@ fn metadata_len(path: &Path) -> u64 {
     std::fs::metadata(path).map_or(0, |m| m.len())
 }
 
-// Synchronous buffered I/O on a dedicated task, intentional: producers
-// drop-on-full via try_send so a stalled filesystem never blocks the
-// analysis path, and rotation runs once per cap_bytes (rare).
-async fn run_writer(
+// Synchronous buffered I/O on a dedicated blocking thread, intentional:
+// producers drop-on-full via try_send so a stalled filesystem never blocks
+// the analysis path, and rotation runs once per cap_bytes (rare). It is a
+// blocking thread rather than a runtime worker because every call in here
+// parks the caller, a truncation and a rotation included, and a worker
+// parked on a slow disk stops polling every other task it holds.
+fn run_writer(
     mut rx: Receiver<OwnedArchive>,
-    path: PathBuf,
+    path: &Path,
     initial_file: File,
     initial_bytes: u64,
     cap_bytes: u64,
     max_files: u32,
-    metrics: Arc<MetricsState>,
+    metrics: &Arc<MetricsState>,
 ) {
     let mut file = initial_file;
     let mut bytes_written = initial_bytes;
-    let (mut prev, mut seq) = resume_chain(&path);
-    while let Some(archive) = rx.recv().await {
+    let (mut prev, mut seq) = resume_chain(path);
+    while let Some(archive) = rx.blocking_recv() {
         let line = match serialize_envelope(&archive, &prev, seq, metrics.archive_drops_total()) {
             Ok(line) => line,
             Err(err) => {
@@ -285,7 +296,7 @@ async fn run_writer(
         seq = seq.saturating_add(1);
         bytes_written = bytes_written.saturating_add(line.len() as u64 + 1);
         if cap_bytes > 0 && bytes_written >= cap_bytes {
-            match rotate(&path, &mut file, max_files) {
+            match rotate(path, &mut file, max_files) {
                 // A rotated file opens a fresh chain: the reader treats a
                 // seed-rooted first line as a start, not as a break.
                 Ok(()) => {

--- a/crates/sentinel-core/src/daemon/incidents.rs
+++ b/crates/sentinel-core/src/daemon/incidents.rs
@@ -309,7 +309,7 @@ pub fn spawn_archive(
 ) -> std::io::Result<ArchiveHandle> {
     let file = open_archive(std::path::Path::new(path))?;
     let (tx, rx) = mpsc::channel::<Vec<u8>>(ARCHIVE_CHANNEL_CAPACITY);
-    let join = tokio::spawn(run_writer(rx, file, metrics));
+    let join = tokio::task::spawn_blocking(move || run_writer(rx, file, &metrics));
     Ok(ArchiveHandle { tx, join })
 }
 
@@ -372,14 +372,17 @@ pub fn open_archive(path: &std::path::Path) -> std::io::Result<std::fs::File> {
 }
 
 /// Drain the channel into the file, one `write` per record.
-async fn run_writer(
+///
+/// On a blocking thread, not a runtime worker: the write and the recovery
+/// that follows a partial one both park the caller.
+fn run_writer(
     mut rx: mpsc::Receiver<Vec<u8>>,
     mut file: std::fs::File,
-    metrics: Arc<crate::report::metrics::MetricsState>,
+    metrics: &Arc<crate::report::metrics::MetricsState>,
 ) {
     use std::io::Write as _;
 
-    while let Some(mut line) = rx.recv().await {
+    while let Some(mut line) = rx.blocking_recv() {
         line.push(b'\n');
         if let Err(error) = file.write_all(&line) {
             metrics.incidents_archive_failed_total.inc();

--- a/crates/sentinel-core/src/daemon/json_socket.rs
+++ b/crates/sentinel-core/src/daemon/json_socket.rs
@@ -32,7 +32,7 @@ pub(super) async fn run_json_socket(
     // the daemon user owns) and the `remove_file` on the next line
     // would follow the symlink and delete the target. `symlink_metadata`
     // does NOT follow symlinks, so we can detect and refuse safely.
-    match std::fs::symlink_metadata(path) {
+    match tokio::fs::symlink_metadata(path).await {
         Ok(meta) if meta.file_type().is_symlink() => {
             tracing::error!(
                 "Refusing to bind Unix socket at {path}: path is a \
@@ -46,7 +46,7 @@ pub(super) async fn run_json_socket(
 
     // Clean up stale socket file (now verified to be a regular file or
     // absent).
-    let _ = std::fs::remove_file(path);
+    let _ = tokio::fs::remove_file(path).await;
 
     let listener = match UnixListener::bind(path) {
         Ok(l) => l,
@@ -73,11 +73,13 @@ pub(super) async fn run_json_socket(
     // Restrict socket permissions to owner-only (prevent other local users from injecting events)
     {
         use std::os::unix::fs::PermissionsExt;
-        if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)) {
+        if let Err(e) =
+            tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await
+        {
             tracing::error!(
                 "Failed to set socket permissions on {path}: {e}, refusing to listen on insecure socket"
             );
-            let _ = std::fs::remove_file(path);
+            let _ = tokio::fs::remove_file(path).await;
             return;
         }
     }

--- a/crates/sentinel-core/src/daemon/mod.rs
+++ b/crates/sentinel-core/src/daemon/mod.rs
@@ -473,7 +473,7 @@ pub async fn run(config: Config) -> Result<(), DaemonError> {
 
     #[cfg(unix)]
     {
-        let _ = std::fs::remove_file(&config.daemon.json_socket);
+        let _ = tokio::fs::remove_file(&config.daemon.json_socket).await;
     }
     loop_result
 }

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -603,7 +603,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.22.0"
+      PERF_SENTINEL_VERSION: "0.22.1"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/FR/CI-FR.md
+++ b/docs/FR/CI-FR.md
@@ -721,7 +721,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.22.0"
+      PERF_SENTINEL_VERSION: "0.22.1"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/docs/ci-templates/github-actions-baseline.yml
+++ b/docs/ci-templates/github-actions-baseline.yml
@@ -41,7 +41,7 @@ jobs:
     name: Publish trunk baseline to gh-pages
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.22.0"
+      PERF_SENTINEL_VERSION: "0.22.1"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/github-actions.yml
+++ b/docs/ci-templates/github-actions.yml
@@ -67,7 +67,7 @@ jobs:
     name: Performance anti-pattern scan
     runs-on: ubuntu-latest
     env:
-      PERF_SENTINEL_VERSION: "0.22.0"
+      PERF_SENTINEL_VERSION: "0.22.1"
       PERF_SENTINEL_TRACES: "test-traces.json"
       PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/gitlab-ci.yml
+++ b/docs/ci-templates/gitlab-ci.yml
@@ -28,7 +28,7 @@ stages:
   - perf-sentinel
 
 variables:
-  PERF_SENTINEL_VERSION: "0.22.0"
+  PERF_SENTINEL_VERSION: "0.22.1"
   PERF_SENTINEL_TRACES: "test-traces.json"
   PERF_SENTINEL_CONFIG: ".perf-sentinel.toml"
 

--- a/docs/ci-templates/jenkinsfile.groovy
+++ b/docs/ci-templates/jenkinsfile.groovy
@@ -113,7 +113,7 @@ pipeline {
     }
 
     environment {
-        PERF_SENTINEL_VERSION = '0.22.0'
+        PERF_SENTINEL_VERSION = '0.22.1'
         PERF_SENTINEL_TRACES  = 'target/traces.json'
         PERF_SENTINEL_CONFIG  = '.perf-sentinel.toml'
     }

--- a/docs/schemas/examples/example-internal-G1.json
+++ b/docs/schemas/examples/example-internal-G1.json
@@ -203,7 +203,7 @@
   "integrity": {
     "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "binary_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.22.0",
+    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.22.1",
     "trace_integrity_chain": null,
     "signature": null
   },

--- a/docs/schemas/examples/example-official-public-G2.json
+++ b/docs/schemas/examples/example-official-public-G2.json
@@ -166,7 +166,7 @@
   "integrity": {
     "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     "binary_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.22.0",
+    "binary_verification_url": "https://github.com/robintra/perf-sentinel/releases/tag/v0.22.1",
     "trace_integrity_chain": null,
     "signature": null
   },

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -761,7 +761,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perf-sentinel-core"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "axum",
  "chrono",

--- a/release-gate/lab-validations.txt
+++ b/release-gate/lab-validations.txt
@@ -205,3 +205,21 @@ v0.21.0	070998a	2026-09-10	PASS
 # ConfigMap and the same receiver refused the same delivery at the same
 # instant. `make validate` ok, 3508 product tests green.
 v0.22.0	05ae8d8	2026-09-11	PASS
+
+# v0.22.1, 2026-09-11. Targeted pass, and narrower than the one above it. The
+# diff is nine blocking file operations moved off the runtime workers, so the
+# scope is the daemon's write paths and nothing else: no detector, no ingest,
+# no scoring, no route, no wire format. The two archive writers keep their
+# bodies byte for byte and only change the kind of thread they run on.
+#
+# Run locally, no cluster, all five green: archive-integrity-chain (the chain
+# hashing and the writer), archive-window-drops (rotation and drops),
+# incident-window-capture (the incident archive writer), java-ci-capture
+# (capture finish) and appsec-hardening (the JSON socket and the ack routes).
+# Those cover eight of the nine changed call sites.
+#
+# NOT exercised, and stated rather than glossed: the socket `remove_file` on
+# the daemon shutdown path, which daemon-sigterm-drain owns and which needs a
+# cluster. It is the most trivial of the nine, a one-shot unlink of a Unix
+# socket during teardown. Operator accepted that gap on 2026-09-11.
+v0.22.1	05ae8d8	2026-09-11	PASS


### PR DESCRIPTION
## Summary

Release 0.22.1. The quality gate went red on `main` at 2026-09-11 10:06, in the analysis where SonarCloud changed its `Sonar way (rust)` profile. That activated `rust:S7493` and surfaced nine blocking file operations sitting in `async` functions, none of them in a file 0.22.0 touched. They are real, all nine park a runtime worker, and this release fixes them. See [CHANGELOG.md](https://github.com/robintra/perf-sentinel/blob/main/CHANGELOG.md) for the detail.

## Changes

- The archive writer and the incident archive writer move to `tokio::task::spawn_blocking` and read their channel with `blocking_recv`. Their bodies are untouched, so the chain hashing, the rotation and the recovery after a partial write are byte-identical, and the synchronous buffered I/O their own comment calls intentional stays exactly that. It stops holding a worker that polls other tasks
- The other seven are one-shot setup and teardown and move to `tokio::fs`: four in the JSON socket listener (`symlink_metadata`, the stale-socket `remove_file`, `set_permissions`, the failure-path `remove_file`), the socket cleanup on daemon shutdown, and the output identity check in `capture finish`
- `run_writer` now takes `&Path` and `&Arc<MetricsState>`, which `clippy::needless_pass_by_value` asks for once the function is no longer `async` and no Future holds its arguments
- `ci.yml` passes `-Dsonar.projectVersion`, read from `[workspace.package].version`. Every analysis so far recorded `version=not provided`, so the "previous version" new-code period never moved and still reached back to 2026-03-14, which is how a newly activated rule reddened the gate over six months of untouched code
- 0.22.1 bump, Helm chart in lockstep, a `v0.22.1` PASS line in the lab ledger

Nine issues was the whole of this project's bug debt on `main`, so this takes it to zero.

Validated in the simulation lab without a cluster, five scenarios green: `archive-integrity-chain` (the chain hashing and the writer), `archive-window-drops` (rotation and drops), `incident-window-capture` (the incident archive writer), `java-ci-capture` (`capture finish`) and `appsec-hardening` (the JSON socket and the ack routes). They cover eight of the nine changed call sites. The ninth, the socket `remove_file` on the shutdown path, belongs to `daemon-sigterm-drain` and needs a cluster: the ledger entry says so rather than glossing it.

## Checklist

Cargo:

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Default-features build AND `--no-default-features` build both pass when touching `daemon/`, `ingest/otlp/`, `ingest/tempo.rs`, `ingest/jaeger_query.rs` or any `#[cfg(feature = "...")]` code

Documentation and assets:

- [x] Public-facing docs updated (`README.md`, `README-FR.md`, relevant files under `docs/` and `docs/FR/`). Nothing user-facing moves, and no doc names the thread these writers run on
- [x] Captures regenerated when CLI output, TUI, or HTML dashboard changed (`vhs tapes/<x>.tape`, `npm run demo` in `crates/sentinel-cli/tests/browser/`). No CLI, TUI or dashboard output changes
- [x] `CHANGELOG.md` entry added under the upcoming version section

Versioning (release PRs only):

- [x] `workspace.package.version` bumped in root `Cargo.toml`
- [x] Intra-workspace `perf-sentinel-core = { version = "x.y.z", path = ... }` pin synced in `crates/sentinel-cli/Cargo.toml`
- [x] `PERF_SENTINEL_VERSION` synced in `docs/ci-templates/` and the snippets in `docs/CI.md` / `docs/FR/CI-FR.md`
- [x] `charts/perf-sentinel/Chart.yaml` (Helm chart) bumped in lockstep: chart `version`, `appVersion`, the `artifacthub.io/images` tag and a new `artifacthub.io/changes` entry, plus the matching `charts/perf-sentinel/CHANGELOG.md` section
- [x] `./scripts/check-tag-version.sh vX.Y.Z` passes locally
- [x] `./scripts/check-chart-appversion-annotation.sh` and `./scripts/check-chart-version-bumped.sh main` pass locally

## Related issues

n/a
